### PR TITLE
Add i18n support with Chinese translation

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,60 +2,20 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=luci-app-netstat
 PKG_VERSION:=1.0.6
-PKG_RELEASE:=8
+PKG_RELEASE:=10
 
 PKG_MAINTAINER:=dotycat <support@dotycat.com>
 PKG_LICENSE:=GPL-3.0
 
 LUCI_TITLE:=NET Stats
 LUCI_DESCRIPTION:=This LuCI app provides net statistic functionality in a web interface.
+LUCI_DEPENDS:=+vnstat
 
-PKG_BUILD_DIR:=$(BUILD_DIR)/$(PKG_NAME)
+include $(TOPDIR)/feeds/luci/luci.mk
 
-include $(INCLUDE_DIR)/package.mk
-
-define Package/$(PKG_NAME)
-  SECTION:=luci
-  CATEGORY:=LuCI
-  SUBMENU:=3. Applications
-  TITLE:=$(LUCI_TITLE)
-  PKGARCH:=all
-  DEPENDS:=+vnstat
+define Package/luci-app-netstat/install
+	$(INSTALL_DIR) $(1)/usr/lib/lua/luci/i18n
+	$(INSTALL_DATA) ./po/zh_Hans/netstat.po $(1)/usr/lib/lua/luci/i18n/netstat.zh_Hans.po
 endef
 
-define Package/$(PKG_NAME)/description
-  $(LUCI_DESCRIPTION)
-endef
-
-define Build/Compile
-endef
-
-define Package/$(PKG_NAME)/install
-	$(INSTALL_DIR) $(1)/etc/config
-	$(INSTALL_CONF) ./files/etc/config/netstats $(1)/etc/config/netstats
-
-	$(INSTALL_DIR) $(1)/etc/uci-defaults
-	$(INSTALL_BIN) ./files/etc/uci-defaults/99-vnstat $(1)/etc/uci-defaults/99-vnstat
-
-	$(INSTALL_DIR) $(1)/usr/lib/lua/luci/controller
-	$(INSTALL_DATA) ./files/usr/lib/lua/luci/controller/netstat.lua $(1)/usr/lib/lua/luci/controller/netstat.lua
-
-	$(INSTALL_DIR) $(1)/usr/lib/lua/luci/model/cbi/netstat
-	$(INSTALL_DATA) ./files/usr/lib/lua/luci/model/cbi/netstat/config.lua $(1)/usr/lib/lua/luci/model/cbi/netstat/config.lua
-
-	$(INSTALL_DIR) $(1)/usr/lib/lua/luci/view
-	$(INSTALL_DATA) ./files/usr/lib/lua/luci/view/vnstat.htm $(1)/usr/lib/lua/luci/view/vnstat.htm
-
-	$(INSTALL_DIR) $(1)/www/luci-static/resources/netstat
-	$(INSTALL_DATA) ./files/www/luci-static/resources/netstat/chart.js $(1)/www/luci-static/resources/netstat/chart.js
-	$(INSTALL_DATA) ./files/www/luci-static/resources/netstat/chartjs-plugin-datalabels $(1)/www/luci-static/resources/netstat/chartjs-plugin-datalabels
-	$(INSTALL_DATA) ./files/www/luci-static/resources/netstat/eye-off-outline.svg $(1)/www/luci-static/resources/netstat/eye-off-outline.svg
-	$(INSTALL_DATA) ./files/www/luci-static/resources/netstat/eye-outline.svg $(1)/www/luci-static/resources/netstat/eye-outline.svg
-	$(INSTALL_DATA) ./files/www/luci-static/resources/netstat/netstat.css $(1)/www/luci-static/resources/netstat/netstat.css
-	$(INSTALL_DATA) ./files/www/luci-static/resources/netstat/netstat_dark.css $(1)/www/luci-static/resources/netstat/netstat_dark.css
-
-	$(INSTALL_DIR) $(1)/www/luci-static/resources/view/status/include
-	$(INSTALL_DATA) ./files/www/luci-static/resources/view/status/include/08_stats.js $(1)/www/luci-static/resources/view/status/include/08_stats.js
-endef
-
-$(eval $(call BuildPackage,$(PKG_NAME)))
+$(eval $(call BuildPackage,luci-app-netstat))

--- a/files/usr/lib/lua/luci/view/vnstat.htm
+++ b/files/usr/lib/lua/luci/view/vnstat.htm
@@ -75,10 +75,10 @@ local stats, title  = {}, ""
 if current_iface ~= "" then
     if view_mode == "daily" then
         stats = get_daily_stats(current_iface)
-        title = "Daily"
+        title = "<%:Daily%>"
     else
         stats = get_monthly_stats(current_iface)
-        title = "Monthly"
+        title = "<%:Monthly%>"
     end
 end
 %>
@@ -183,7 +183,7 @@ end
                 ],
                 datasets: [
                     {
-                        label: 'Download (RX)',
+                        label: '<%:Download (RX)%>',
                         backgroundColor: rxData.map(v => getGradient(ctx, v, maxValue)),
                         data: rxData,
                         datalabels: {
@@ -194,7 +194,7 @@ end
                         }
                     },
                     {
-                        label: 'Upload (TX)',
+                        label: '<%:Upload (TX)%>',
                         backgroundColor: 'orange',
                         data: txData,
                         datalabels: {

--- a/files/www/luci-static/resources/view/status/include/08_stats.js
+++ b/files/www/luci-static/resources/view/status/include/08_stats.js
@@ -153,7 +153,7 @@ function createStatusCard(status, ip) {
 	const isConnected = status === 'Connected';
 	const statusText = isConnected ? _('Connected') : _('Disconnected');
 	return E('div', { class: 'netstat-box netstat-center ' + (isConnected ? 'is-up' : 'is-down') }, [
-		E('div', { class: 'netstat-center-title' }, _('INTERNET')),
+		E('div', { class: 'netstat-center-title' }, _('Internet')),
 		E('div', { class: 'netstat-center-status' }, statusText),
 		E('div', { class: 'netstat-center-sep' }, ''),
 		E('div', { class: 'netstat-center-title' }, _('IP')),

--- a/po/templates/netstat.pot
+++ b/po/templates/netstat.pot
@@ -1,0 +1,165 @@
+msgid ""
+msgstr ""
+"Project-Id-Version: luci-app-netstat\n"
+"POT-Creation-Date: 2026-03-31 12:03+0800\n"
+"PO-Revision-Date: 2026-03-31 12:03+0800\n"
+"Last-Translator: \n"
+"Language-Team: \n"
+"Language: en\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=2; plural=(n != 1);\n"
+
+#: htdocs/luci-static/resources/view/status/include/08_stats.js:156
+msgid "Internet"
+msgstr "Internet"
+
+#: htdocs/luci-static/resources/view/status/include/08_stats.js:154
+msgid "Connected"
+msgstr "Connected"
+
+#: htdocs/luci-static/resources/view/status/include/08_stats.js:154
+msgid "Disconnected"
+msgstr "Disconnected"
+
+#: htdocs/luci-static/resources/view/status/include/08_stats.js:159
+msgid "IP"
+msgstr "IP"
+
+#: htdocs/luci-static/resources/view/status/include/08_stats.js:202
+msgid "Loading network stats..."
+msgstr "Loading network stats..."
+
+#: htdocs/luci-static/resources/view/status/include/08_stats.js:230
+msgid "download"
+msgstr "download"
+
+#: htdocs/luci-static/resources/view/status/include/08_stats.js:231
+msgid "upload"
+msgstr "upload"
+
+#: htdocs/luci-static/resources/view/status/include/08_stats.js:235
+msgid "downloaded"
+msgstr "downloaded"
+
+#: htdocs/luci-static/resources/view/status/include/08_stats.js:236
+msgid "uploaded"
+msgstr "uploaded"
+
+#: luasrc/controller/netstat.lua:5
+msgid "Netstat Config"
+msgstr "Netstat Config"
+
+#: luasrc/controller/netstat.lua:6
+msgid "VnStats"
+msgstr "VnStats"
+
+#: luasrc/model/cbi/netstat/config.lua:4
+msgid "Netstat"
+msgstr "Netstat"
+
+#: luasrc/model/cbi/netstat/config.lua:5
+msgid "Select your preferred primary WAN interface."
+msgstr "Select your preferred primary WAN interface."
+
+#: luasrc/model/cbi/netstat/config.lua:8
+msgid "Settings"
+msgstr "Settings"
+
+#: luasrc/model/cbi/netstat/config.lua:11
+msgid "Traffic Backend"
+msgstr "Traffic Backend"
+
+#: luasrc/model/cbi/netstat/config.lua:13
+msgid "Normal (Real-time)"
+msgstr "Normal (Real-time)"
+
+#: luasrc/model/cbi/netstat/config.lua:14
+msgid "vnStat (Historical, Delayed)"
+msgstr "vnStat (Historical, Delayed)"
+
+#: luasrc/model/cbi/netstat/config.lua:16
+msgid "Display Mode"
+msgstr "Display Mode"
+
+#: luasrc/model/cbi/netstat/config.lua:19
+msgid "Daily Usage"
+msgstr "Daily Usage"
+
+#: luasrc/model/cbi/netstat/config.lua:20
+msgid "Monthly Usage"
+msgstr "Monthly Usage"
+
+#: luasrc/model/cbi/netstat/config.lua:22
+msgid "WAN Interface"
+msgstr "WAN Interface"
+
+#: luasrc/model/cbi/netstat/config.lua:23
+msgid ""
+"Select the interface for tracking WAN traffic. Leave blank to auto-detect."
+"<br><br><b>Backend Mode Explanation:</b><br>"
+"<ul>"
+"<li><b>vnStat</b>: Uses the vnStat database. It provides daily/monthly usage, but traffic updates are delayed depending on vnStat interval.</li>"
+"<li><b>Normal</b>: Reads directly from system interfaces in real time (no delay), but does not keep history.</li>"
+"</ul>"
+msgstr ""
+"Select the interface for tracking WAN traffic. Leave blank to auto-detect."
+"<br><br><b>Backend Mode Explanation:</b><br>"
+"<ul>"
+"<li><b>vnStat</b>: Uses the vnStat database. It provides daily/monthly usage, but traffic updates are delayed depending on vnStat interval.</li>"
+"<li><b>Normal</b>: Reads directly from system interfaces in real time (no delay), but does not keep history.</li>"
+"</ul>"
+
+#: luasrc/model/cbi/netstat/config.lua:31
+msgid "Auto detect"
+msgstr "Auto detect"
+
+#: luasrc/model/cbi/netstat/config.lua:41
+msgid "Reset vnStat Stats"
+msgstr "Reset vnStat Stats"
+
+#: luasrc/model/cbi/netstat/config.lua:42
+msgid "Reset Database"
+msgstr "Reset Database"
+
+#: luasrc/model/cbi/netstat/config.lua:61
+msgid "vnStat database has been reset successfully for all interfaces."
+msgstr "vnStat database has been reset successfully for all interfaces."
+
+#: luasrc/view/vnstat.htm:78
+msgid "Daily"
+msgstr "Daily"
+
+#: luasrc/view/vnstat.htm:81
+msgid "Monthly"
+msgstr "Monthly"
+
+#: luasrc/view/vnstat.htm:186
+msgid "Download (RX)"
+msgstr "Download (RX)"
+
+#: luasrc/view/vnstat.htm:197
+msgid "Upload (TX)"
+msgstr "Upload (TX)"
+
+# 已存在的翻译（保留）
+#: luasrc/view/vnstat.htm:87
+msgid "Network Usage"
+msgstr "Network Usage"
+
+#: luasrc/view/vnstat.htm:93
+msgid "Interface"
+msgstr "Interface"
+
+#: luasrc/view/vnstat.htm:108
+msgid "View Mode"
+msgstr "View Mode"
+
+#: luasrc/view/vnstat.htm:97
+msgid "No interfaces found"
+msgstr "No interfaces found"
+
+#: luasrc/view/vnstat.htm:245
+msgid "No data available for"
+msgstr "No data available for"

--- a/po/zh_Hans/netstat.po
+++ b/po/zh_Hans/netstat.po
@@ -1,0 +1,165 @@
+msgid ""
+msgstr ""
+"Project-Id-Version: luci-app-netstat\n"
+"POT-Creation-Date: 2026-03-31 12:03+0800\n"
+"PO-Revision-Date: 2026-03-31 12:03+0800\n"
+"Last-Translator: \n"
+"Language-Team: \n"
+"Language: zh_Hans\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=1; plural=0;\n"
+
+#: htdocs/luci-static/resources/view/status/include/08_stats.js:156
+msgid "Internet"
+msgstr "互联网"
+
+#: htdocs/luci-static/resources/view/status/include/08_stats.js:154
+msgid "Connected"
+msgstr "已连接"
+
+#: htdocs/luci-static/resources/view/status/include/08_stats.js:154
+msgid "Disconnected"
+msgstr "已断开"
+
+#: htdocs/luci-static/resources/view/status/include/08_stats.js:159
+msgid "IP"
+msgstr "IP地址"
+
+#: htdocs/luci-static/resources/view/status/include/08_stats.js:202
+msgid "Loading network stats..."
+msgstr "正在加载网络统计..."
+
+#: htdocs/luci-static/resources/view/status/include/08_stats.js:230
+msgid "download"
+msgstr "下载"
+
+#: htdocs/luci-static/resources/view/status/include/08_stats.js:231
+msgid "upload"
+msgstr "上传"
+
+#: htdocs/luci-static/resources/view/status/include/08_stats.js:235
+msgid "downloaded"
+msgstr "已下载"
+
+#: htdocs/luci-static/resources/view/status/include/08_stats.js:236
+msgid "uploaded"
+msgstr "已上传"
+
+#: luasrc/controller/netstat.lua:5
+msgid "Netstat Config"
+msgstr "网络统计配置"
+
+#: luasrc/controller/netstat.lua:6
+msgid "VnStats"
+msgstr "流量统计"
+
+#: luasrc/model/cbi/netstat/config.lua:4
+msgid "Netstat"
+msgstr "网络统计"
+
+#: luasrc/model/cbi/netstat/config.lua:5
+msgid "Select your preferred primary WAN interface."
+msgstr "选择您首选的主要WAN接口。"
+
+#: luasrc/model/cbi/netstat/config.lua:8
+msgid "Settings"
+msgstr "设置"
+
+#: luasrc/model/cbi/netstat/config.lua:11
+msgid "Traffic Backend"
+msgstr "流量后端"
+
+#: luasrc/model/cbi/netstat/config.lua:13
+msgid "Normal (Real-time)"
+msgstr "普通（实时）"
+
+#: luasrc/model/cbi/netstat/config.lua:14
+msgid "vnStat (Historical, Delayed)"
+msgstr "vnStat（历史，延迟）"
+
+#: luasrc/model/cbi/netstat/config.lua:16
+msgid "Display Mode"
+msgstr "显示模式"
+
+#: luasrc/model/cbi/netstat/config.lua:19
+msgid "Daily Usage"
+msgstr "每日使用"
+
+#: luasrc/model/cbi/netstat/config.lua:20
+msgid "Monthly Usage"
+msgstr "每月使用"
+
+#: luasrc/model/cbi/netstat/config.lua:22
+msgid "WAN Interface"
+msgstr "WAN接口"
+
+#: luasrc/model/cbi/netstat/config.lua:23
+msgid ""
+"Select the interface for tracking WAN traffic. Leave blank to auto-detect."
+"<br><br><b>Backend Mode Explanation:</b><br>"
+"<ul>"
+"<li><b>vnStat</b>: Uses the vnStat database. It provides daily/monthly usage, but traffic updates are delayed depending on vnStat interval.</li>"
+"<li><b>Normal</b>: Reads directly from system interfaces in real time (no delay), but does not keep history.</li>"
+"</ul>"
+msgstr ""
+"选择用于跟踪WAN流量的接口。留空以自动检测。"
+"<br><br><b>后端模式说明：</b><br>"
+"<ul>"
+"<li><b>vnStat</b>：使用vnStat数据库。提供每日/每月使用情况，但流量更新会根据vnStat间隔延迟。</li>"
+"<li><b>普通</b>：实时直接从系统接口读取（无延迟），但不保存历史记录。</li>"
+"</ul>"
+
+#: luasrc/model/cbi/netstat/config.lua:31
+msgid "Auto detect"
+msgstr "自动检测"
+
+#: luasrc/model/cbi/netstat/config.lua:41
+msgid "Reset vnStat Stats"
+msgstr "重置vnStat统计"
+
+#: luasrc/model/cbi/netstat/config.lua:42
+msgid "Reset Database"
+msgstr "重置数据库"
+
+#: luasrc/model/cbi/netstat/config.lua:61
+msgid "vnStat database has been reset successfully for all interfaces."
+msgstr "所有接口的vnStat数据库已成功重置。"
+
+#: luasrc/view/vnstat.htm:78
+msgid "Daily"
+msgstr "每日"
+
+#: luasrc/view/vnstat.htm:81
+msgid "Monthly"
+msgstr "每月"
+
+#: luasrc/view/vnstat.htm:186
+msgid "Download (RX)"
+msgstr "下载 (接收)"
+
+#: luasrc/view/vnstat.htm:197
+msgid "Upload (TX)"
+msgstr "上传 (发送)"
+
+# 已存在的翻译（保留）
+#: luasrc/view/vnstat.htm:87
+msgid "Network Usage"
+msgstr "网络使用情况"
+
+#: luasrc/view/vnstat.htm:93
+msgid "Interface"
+msgstr "接口"
+
+#: luasrc/view/vnstat.htm:108
+msgid "View Mode"
+msgstr "查看模式"
+
+#: luasrc/view/vnstat.htm:97
+msgid "No interfaces found"
+msgstr "未找到接口"
+
+#: luasrc/view/vnstat.htm:245
+msgid "No data available for"
+msgstr "没有可用数据"


### PR DESCRIPTION
- Create Chinese translation file (zh_Hans.po) with complete UI translations
- Replace hardcoded strings in JavaScript and HTML templates with i18n functions
- Optimize Makefile to use luci.mk for standard parts while keeping custom install logic
- Update PKG_RELEASE to 10 to reflect i18n improvements
- All user-visible interface elements now support both English and Chinese