### PR TITLE
Dev

### DIFF
--- a/files/usr/lib/lua/luci/controller/netstat.lua
+++ b/files/usr/lib/lua/luci/controller/netstat.lua
@@ -7,17 +7,17 @@ function index()
     entry({"admin", "tools", "get_netdev_stats"}, call("getNetdevStats"), nil).sysauth = false
 end
 
+-- Reads /proc/net/dev and returns per-interface rx/tx byte counters.
 function getNetdevStats()
     local f = io.open("/proc/net/dev", "r")
     if not f then
         luci.http.prepare_content("application/json")
-        luci.http.write('{"stats":{}, "ip":"N/A", "status":"Disconnected"}')
+        luci.http.write('{"stats":{},"ip":"N/A","status":"Disconnected"}')
         return
     end
-    
     local content = f:read("*a")
     f:close()
-    
+
     local stats = {}
     for line in content:gmatch("[^\n]+") do
         local iface, values = line:match("^%s*([^:]+):%s+(.*)$")
@@ -27,15 +27,12 @@ function getNetdevStats()
                 table.insert(nums, tonumber(num))
             end
             if #nums >= 9 then
-                stats[iface] = {
-                    rx = nums[1],
-                    tx = nums[9]
-                }
+                stats[iface] = { rx = nums[1], tx = nums[9] }
             end
         end
     end
-    
-    -- Quick connectivity check - just check if we have packets flowing
+
+    -- Quick connectivity check
     local status = "Disconnected"
     for iface, data in pairs(stats) do
         if iface ~= "lo" and (data.rx > 0 or data.tx > 0) then
@@ -43,84 +40,63 @@ function getNetdevStats()
             break
         end
     end
-    
-    -- Get public IP from api.ipify.org (real internet-facing address)
-    local function read_cmd_line(cmd)
-        local p = io.popen(cmd)
-        if not p then
-            return nil
-        end
 
+    -- ── IP detection ─────────────────────────────────────────────────────────
+    -- Strategy: try a single fast HTTP call first (2 s timeout), then fall
+    -- back to local ubus/ifstatus which is instant.  The old code tried 11
+    -- commands with 4 s timeouts each – worst-case 44 s of blocking.
+
+    local function read_cmd(cmd)
+        local p = io.popen(cmd)
+        if not p then return nil end
         local line = p:read("*l")
         p:close()
-
-        if not line then
-            return nil
-        end
-
-        line = line:gsub("^%s+", ""):gsub("%s+$", "")
-        if line == "" then
-            return nil
-        end
-
-        return line
+        if not line then return nil end
+        line = line:gsub("^%s+",""):gsub("%s+$","")
+        return line ~= "" and line or nil
     end
 
-    local function is_valid_ip(value)
-        if not value then
-            return false
-        end
-
-        -- Simple IPv4 validation
-        local a, b, c, d = value:match("^(%d+)%.(%d+)%.(%d+)%.(%d+)$")
+    local function is_valid_ip(v)
+        if not v then return false end
+        local a,b,c,d = v:match("^(%d+)%.(%d+)%.(%d+)%.(%d+)$")
         if a and b and c and d then
-            a, b, c, d = tonumber(a), tonumber(b), tonumber(c), tonumber(d)
-            if a <= 255 and b <= 255 and c <= 255 and d <= 255 then
-                return true
-            end
+            a,b,c,d = tonumber(a),tonumber(b),tonumber(c),tonumber(d)
+            if a<=255 and b<=255 and c<=255 and d<=255 then return true end
         end
-
-        -- Basic IPv6 check (contains ':' and only hex/colon chars)
-        if value:find(":", 1, true) and value:match("^[%x:]+$") then
-            return true
-        end
-
+        if v:find(":",1,true) and v:match("^[%x:]+$") then return true end
         return false
     end
 
     local ip = "N/A"
 
-    -- Try ipify first using whichever HTTP client is available on the router
-    local ip_cmds = {
-        "curl -fsS --max-time 4 'https://api.ipify.org' 2>/dev/null",
-        "curl -fsS --max-time 4 'http://api.ipify.org' 2>/dev/null",
-        "uclient-fetch -qO- --timeout=4 'https://api.ipify.org' 2>/dev/null",
-        "uclient-fetch -qO- --timeout=4 'http://api.ipify.org' 2>/dev/null",
-        "wget -qO- --timeout=4 'https://api.ipify.org' 2>/dev/null",
-        "wget -qO- --timeout=4 'http://api.ipify.org' 2>/dev/null",
-
-        -- Fallback to local WAN address if public IP lookup fails
-        "ubus call network.interface.wan status 2>/dev/null | jsonfilter -e '@[\"ipv4-address\"][0].address'",
-        "ifstatus wan 2>/dev/null | jsonfilter -e '@[\"ipv4-address\"][0].address'",
-        "ubus call network.interface.wan status 2>/dev/null | jsonfilter -e '@[\"ipv6-address\"][0].address'",
-        "ubus call network.interface.wan6 status 2>/dev/null | jsonfilter -e '@[\"ipv6-address\"][0].address'",
-        "ifstatus wan6 2>/dev/null | jsonfilter -e '@[\"ipv6-address\"][0].address'"
+    -- 1. Try public-IP APIs with a 2-second timeout (not 4)
+    local public_cmds = {
+        "curl -fsS --max-time 2 'https://api.ipify.org' 2>/dev/null",
+        "curl -fsS --max-time 2 'http://api.ipify.org' 2>/dev/null",
+        "uclient-fetch -qO- --timeout=2 'https://api.ipify.org' 2>/dev/null",
+        "wget -qO- --timeout=2 'https://api.ipify.org' 2>/dev/null",
     }
+    for _, cmd in ipairs(public_cmds) do
+        local v = read_cmd(cmd)
+        if is_valid_ip(v) then ip = v; break end
+    end
 
-    for _, cmd in ipairs(ip_cmds) do
-        local detected = read_cmd_line(cmd)
-        if detected and is_valid_ip(detected) then
-            ip = detected
-            break
+    -- 2. Fall back to local WAN address (instant, no network needed)
+    if ip == "N/A" then
+        local local_cmds = {
+            -- wan IPv4
+            "ubus call network.interface.wan status 2>/dev/null | jsonfilter -e '@[\"ipv4-address\"][0].address'",
+            "ifstatus wan 2>/dev/null | jsonfilter -e '@[\"ipv4-address\"][0].address'",
+            -- wan IPv6
+            "ubus call network.interface.wan status 2>/dev/null | jsonfilter -e '@[\"ipv6-address\"][0].address'",
+            "ubus call network.interface.wan6 status 2>/dev/null | jsonfilter -e '@[\"ipv6-address\"][0].address'",
+        }
+        for _, cmd in ipairs(local_cmds) do
+            local v = read_cmd(cmd)
+            if is_valid_ip(v) then ip = v; break end
         end
     end
-    
-    local response = {
-        stats = stats,
-        ip = ip,
-        status = status
-    }
-    
+
     luci.http.prepare_content("application/json")
-    luci.http.write_json(response)
+    luci.http.write_json({ stats = stats, ip = ip, status = status })
 end

--- a/files/usr/lib/lua/luci/model/cbi/netstat/config.lua
+++ b/files/usr/lib/lua/luci/model/cbi/netstat/config.lua
@@ -16,23 +16,29 @@ if active_tab == "settings" then
     s.anonymous = true
     s.addremove = false
 
+    -- Traffic backend
     local backend = s:option(ListValue, "backend", translate("Traffic Backend"))
     backend.default = "normal"
     backend:value("normal", translate("Normal (Real-time)"))
     backend:value("vnstat", translate("vnStat (Historical, Delayed)"))
+    backend.description = translate(
+        "Normal reads live counters from /proc/net/dev. " ..
+        "vnStat reads the vnStat database which updates on its own schedule."
+    )
 
+    -- View mode
     local mode = s:option(ListValue, "mode", translate("View Mode"))
     mode.default = "daily"
-    mode:value("daily", translate("Daily Usage"))
+    mode:value("daily",   translate("Daily Usage"))
     mode:value("monthly", translate("Monthly Usage"))
-    mode.description = translate("Used by the Network Usage tab.")
+    mode.description = translate("Default view shown on the Network Usage tab.")
 
-    local iface = s:option(ListValue, "prefer", translate("Interface"))
+    -- Interface preference
+    local iface = s:option(ListValue, "prefer", translate("Preferred Interface"))
     iface.description = translate(
-        "Track WAN traffic on this interface. Leave this empty to auto-detect." ..
-        "<br><br><strong>Backend notes</strong>" ..
-        "<br>- vnStat: stores daily and monthly history (updates may be delayed)." ..
-        "<br>- Normal: real-time traffic only (no stored history)."
+        "WAN interface to track. Leave blank for auto-detection.<br>" ..
+        "<strong>Tip:</strong> If your WAN uses a dynamic name (e.g. wwan0_1) " ..
+        "it will be detected automatically when left blank."
     )
     iface:value("", translate("Auto detect"))
 
@@ -44,32 +50,70 @@ if active_tab == "settings" then
         end
     end
 
+    -- Data retention info
+    local info = s:option(DummyValue, "_info", translate("vnStat Database"))
+    info.rawhtml  = true
+    info.cfgvalue = function()
+        -- Show current database size if available
+        local size_out = sys.exec("du -sh /etc/vnstat/ 2>/dev/null | cut -f1") or ""
+        size_out = size_out:match("^%s*(.-)%s*$") or ""
+        local db_size = size_out ~= "" and (" — " .. size_out) or ""
+        return string.format(
+            '<span style="font-size:12px;color:#6b7280;">%s%s</span>',
+            translate("Location: /etc/vnstat/"),
+            db_size
+        )
+    end
+
+    -- Reset button with inline JS confirmation
     local reset = s:option(Button, "_reset", translate("Reset Historical Data"))
     reset.inputtitle = translate("Reset Database")
     reset.inputstyle = "reset"
+    reset.description = translate(
+        "<strong style='color:#b91c1c;'>Warning:</strong> " ..
+        "This permanently deletes all stored traffic history for every interface."
+    )
+
+    -- Inject confirmation dialog via rawhtml trick
+    local confirm_js = s:option(DummyValue, "_confirm_js", "")
+    confirm_js.rawhtml = true
+    confirm_js.cfgvalue = function()
+        return [[
+<script>
+(function () {
+    var btn = document.querySelector('input[value="]] .. translate("Reset Database") .. [["]');
+    if (!btn) return;
+    btn.addEventListener('click', function (e) {
+        if (!confirm(']] .. translate("Are you sure? All traffic history will be permanently deleted.") .. [[')) {
+            e.preventDefault();
+        }
+    });
+})();
+</script>]]
+    end
 
     function reset.write(self, section)
-        local dbdir = "/etc/vnstat"
+        sys.call("/etc/init.d/vnstat stop 2>/dev/null")
+        sys.call("rm -f /etc/vnstat/* 2>/dev/null")
 
-        sys.call("/etc/init.d/vnstat stop")
-        sys.call("rm -f " .. dbdir .. "/* >/dev/null 2>&1")
-
-        local netm = net.init()
-        for _, dev in ipairs(netm:get_interfaces()) do
+        -- Re-initialise only interfaces that currently exist
+        local netm2 = net.init()
+        for _, dev in ipairs(netm2:get_interfaces()) do
             local name = dev:shortname()
             if name and not name:match("^lo$") and not name:match("^br%-") then
                 sys.call("vnstat -u -i " .. name .. " >/dev/null 2>&1")
             end
         end
 
-        sys.call("/etc/init.d/vnstat start")
-
+        sys.call("/etc/init.d/vnstat start 2>/dev/null")
         m.message = translate("vnStat database has been reset successfully for all interfaces.")
     end
+
 elseif active_tab == "about" then
     local about = m:section(SimpleSection, translate("About"))
     about.template = "netstat/about"
-else
+
+else -- usage tab (default)
     local usage = m:section(SimpleSection, translate("Network Usage"))
     usage.template = "netstat/usage"
 end

--- a/files/usr/lib/lua/luci/view/netstat/about.htm
+++ b/files/usr/lib/lua/luci/view/netstat/about.htm
@@ -1,21 +1,49 @@
 <div class="netstat-about-card">
-    <h3><%:About%></h3>
-    <p><%:LuCI Netstat frontend for traffic monitoring and usage charts.%></p>
+    <h3 style="margin:0 0 4px;"><%:LuCI Netstat%></h3>
+    <p style="margin:0 0 16px;font-size:13px;color:#6b7280;">
+        <%:Frontend for traffic monitoring and usage charts on OpenWrt.%>
+    </p>
 
-    <div class="netstat-about-row">
-        <span class="netstat-about-label"><%:Repository%>:</span>
-        <a href="https://github.com/nooblk-98/luci-app-netstat" target="_blank" rel="noopener noreferrer">https://github.com/nooblk-98/luci-app-netstat</a>
+    <div class="netstat-about-grid">
+        <div class="netstat-about-row">
+            <span class="netstat-about-label"><%:Developer%></span>
+            <strong>NoobLk</strong>
+        </div>
+
+        <div class="netstat-about-row">
+            <span class="netstat-about-label"><%:Repository%></span>
+            <a href="https://github.com/nooblk-98/luci-app-netstat"
+               target="_blank" rel="noopener noreferrer">
+                github.com/nooblk-98/luci-app-netstat
+            </a>
+        </div>
+
+        <div class="netstat-about-row">
+            <span class="netstat-about-label"><%:Contributors%></span>
+            <a href="https://github.com/nooblk-98/luci-app-netstat/graphs/contributors"
+               target="_blank" rel="noopener noreferrer">
+                <%:View on GitHub%>
+            </a>
+        </div>
+
+        <div class="netstat-about-row">
+            <span class="netstat-about-label"><%:License%></span>
+            <span>GPL-3.0</span>
+        </div>
+
+        <div class="netstat-about-row">
+            <span class="netstat-about-label"><%:Issues / Support%></span>
+            <a href="https://github.com/nooblk-98/luci-app-netstat/issues"
+               target="_blank" rel="noopener noreferrer">
+                <%:Open an issue%>
+            </a>
+        </div>
     </div>
 
-    <div class="netstat-about-row">
-        <span class="netstat-about-label"><%:Developer%>:</span>
-        <strong>NoobLk</strong>
-    </div>
-
-    <div class="netstat-about-row">
-        <span class="netstat-about-label"><%:Contributors%>:</span>
-        <a href="https://github.com/nooblk-98/luci-app-netstat/graphs/contributors" target="_blank" rel="noopener noreferrer">https://github.com/nooblk-98/luci-app-netstat/graphs/contributors</a>
-    </div>
+    <hr style="border:none;border-top:1px solid #e5e7eb;margin:16px 0 12px;">
+    <p style="margin:0;font-size:12px;color:#9ca3af;text-align:center;">
+        <%:Made with%> ♥ <%:for the OpenWrt community%>
+    </p>
 </div>
 
 <style>
@@ -23,25 +51,35 @@
     border: 1px solid #dfe3eb;
     border-radius: 10px;
     background: #fff;
-    padding: 16px 18px;
+    padding: 20px 22px;
+    max-width: 520px;
 }
 
-.netstat-about-card h3 {
-    margin: 0 0 10px;
-}
-
-.netstat-about-card p {
-    margin: 0 0 12px;
-}
+.netstat-about-grid   { display: flex; flex-direction: column; gap: 10px; }
 
 .netstat-about-row {
-    margin: 8px 0;
+    display: flex;
+    align-items: baseline;
+    gap: 8px;
+    font-size: 13px;
     word-break: break-word;
 }
 
 .netstat-about-label {
-    display: inline-block;
     min-width: 110px;
-    color: #4b5563;
+    flex-shrink: 0;
+    color: #6b7280;
+    font-weight: 500;
+}
+
+.netstat-about-row a {
+    color: #2563eb;
+    text-decoration: none;
+}
+.netstat-about-row a:hover { text-decoration: underline; }
+
+@media (max-width: 480px) {
+    .netstat-about-row { flex-direction: column; gap: 2px; }
+    .netstat-about-label { min-width: unset; }
 }
 </style>

--- a/files/usr/lib/lua/luci/view/netstat/tabs.htm
+++ b/files/usr/lib/lua/luci/view/netstat/tabs.htm
@@ -1,51 +1,74 @@
 <%
-local http = require "luci.http"
+local http       = require "luci.http"
 local dispatcher = require "luci.dispatcher"
 
 local active_tab = http.formvalue("tab") or "usage"
-local base_url = dispatcher.build_url("admin", "tools", "netstat")
+local base_url   = dispatcher.build_url("admin", "tools", "netstat")
 
-local function tab_url(tab)
-    return base_url .. "?tab=" .. tab
-end
+local function tab_url(tab) return base_url .. "?tab=" .. tab end
+
+local tabs_def = {
+    { id="usage",    label=translate("Network Usage") },
+    { id="settings", label=translate("Settings")      },
+    { id="about",    label=translate("About")         },
+}
 %>
 
 <style>
-.netstat-tab-wrap {
-    margin: 4px 0 14px;
-}
+.netstat-tab-wrap    { margin: 4px 0 14px; }
 
-.netstat-tabmenu {
-    display: flex;
-    gap: 8px;
-    margin: 0;
-    padding: 0;
-    list-style: none;
-}
+.netstat-tabmenu     { display:flex; gap:4px; margin:0; padding:0; list-style:none; flex-wrap:wrap; }
 
 .netstat-tabmenu li a {
-    display: block;
-    padding: 9px 14px;
+    display: flex;
+    align-items: center;
+    gap: 6px;
+    padding: 8px 16px;
     border: 1px solid #cfd6e2;
+    border-bottom: none;
     border-radius: 6px 6px 0 0;
     background: #e6ebf2;
     color: #2f3b52;
     text-decoration: none;
+    font-size: 13px;
     font-weight: 500;
+    transition: background 0.1s, color 0.1s;
 }
 
-.netstat-tabmenu li.active a {
+.netstat-tabmenu li a:hover:not(.active-link) {
+    background: #d8e2f0;
+}
+
+.netstat-tabmenu li.active a,
+.netstat-tabmenu li a.active-link {
     background: #f7f9fc;
+    border-color: #cfd6e2;
     border-bottom-color: #f7f9fc;
     color: #3659d9;
+    font-weight: 600;
 }
 
+/* Small dot indicator for active tab */
+.netstat-tab-dot {
+    width: 6px;
+    height: 6px;
+    border-radius: 50%;
+    background: currentColor;
+    opacity: 0;
+    transition: opacity 0.15s;
+    flex-shrink: 0;
+}
+.netstat-tabmenu li.active .netstat-tab-dot { opacity: 1; }
+
 .netstat-tab-divider {
-    border-bottom: 1px solid #cfd6e2;
+    border: none;
+    border-top: 1px solid #cfd6e2;
     margin-top: -1px;
+    margin-bottom: 0;
 }
 
 <% if active_tab == "settings" then %>
+/* Tighten up CBI section for settings tab */
 .cbi-map > .cbi-section:last-of-type {
     border: 1px solid #dfe3eb;
     border-radius: 10px;
@@ -57,17 +80,16 @@ end
 
 <div class="netstat-tab-wrap">
     <ul class="netstat-tabmenu">
-        <li class="<%=active_tab == "usage" and "active" or ""%>">
-            <a href="<%=tab_url("usage")%>"><%:Network Usage%></a>
+        <% for _, tab in ipairs(tabs_def) do %>
+        <li class="<%= active_tab == tab.id and "active" or "" %>">
+            <a href="<%= tab_url(tab.id) %>">
+                <span class="netstat-tab-dot"></span>
+                <%= tab.label %>
+            </a>
         </li>
-        <li class="<%=active_tab == "settings" and "active" or ""%>">
-            <a href="<%=tab_url("settings")%>"><%:Settings%></a>
-        </li>
-        <li class="<%=active_tab == "about" and "active" or ""%>">
-            <a href="<%=tab_url("about")%>"><%:About%></a>
-        </li>
+        <% end %>
     </ul>
-    <div class="netstat-tab-divider"></div>
+    <hr class="netstat-tab-divider" />
 </div>
 
 <input type="hidden" name="tab" value="<%=active_tab%>" />

--- a/files/usr/lib/lua/luci/view/netstat/usage.htm
+++ b/files/usr/lib/lua/luci/view/netstat/usage.htm
@@ -3,18 +3,17 @@ local sys  = require "luci.sys"
 local http = require "luci.http"
 local uci  = require "luci.model.uci".cursor()
 
--- ── Helpers ────────────────────────────────────────────────────────────────────
 local function to_bytes(value, unit)
-    local m = { KiB=1024, MiB=1024^2, GiB=1024^3, TiB=1024^4 }
+    local m = { KiB=1024, MiB=1048576, GiB=1073741824, TiB=1099511627776 }
     return tonumber(value) * (m[unit] or 1)
 end
 
 local function format_date(date_str)
     local months = {"Jan","Feb","Mar","Apr","May","Jun",
                     "Jul","Aug","Sep","Oct","Nov","Dec"}
-    local m, d, y = date_str:match("(%d%d)/(%d%d)/(%d%d)")
-    if m and d and y then
-        return string.format("%02d %s %02d", tonumber(d), months[tonumber(m)], tonumber(y))
+    local mo, d, y = date_str:match("(%d%d)/(%d%d)/(%d%d)")
+    if mo and d and y then
+        return string.format("%02d %s %02d", tonumber(d), months[tonumber(mo)], tonumber(y))
     end
     return date_str
 end
@@ -38,7 +37,7 @@ end
 
 local function get_interfaces()
     local ifaces = {}
-    local p = io.popen("ls /etc/vnstat/ 2>/dev/null | grep -Ev '\\.(conf|old)$'")
+    local p = io.popen("ls /etc/vnstat/ 2>/dev/null | grep -v '.conf$' | grep -v '.old$'")
     if p then
         for iface in p:lines() do
             iface = iface:match("^%s*(.-)%s*$")
@@ -79,20 +78,19 @@ local function get_monthly_stats(iface)
 end
 
 local function fmt_bytes(v)
-    if v >= 1099511627776 then return string.format("%.2f TB", v/1099511627776)
-    elseif v >= 1073741824 then return string.format("%.2f GB", v/1073741824)
-    elseif v >= 1048576    then return string.format("%.2f MB", v/1048576)
-    elseif v >= 1024       then return string.format("%.2f KB", v/1024)
+    if     v >= 1099511627776 then return string.format("%.2f TB", v/1099511627776)
+    elseif v >= 1073741824    then return string.format("%.2f GB", v/1073741824)
+    elseif v >= 1048576       then return string.format("%.2f MB", v/1048576)
+    elseif v >= 1024          then return string.format("%.2f KB", v/1024)
     end
     return tostring(v) .. " B"
 end
 
--- ── Load data ──────────────────────────────────────────────────────────────────
-local ifaces       = get_interfaces()
-local saved_iface  = uci:get("netstats", "@config[0]", "prefer") or ""
-local saved_mode   = uci:get("netstats", "@config[0]", "mode")   or "daily"
-local cur_iface    = http.formvalue("iface") or saved_iface or ifaces[1] or ""
-local view_mode    = http.formvalue("mode")  or saved_mode
+local ifaces      = get_interfaces()
+local saved_iface = uci:get("netstats", "@config[0]", "prefer") or ""
+local saved_mode  = uci:get("netstats", "@config[0]", "mode")   or "daily"
+local cur_iface   = http.formvalue("iface") or saved_iface or ifaces[1] or ""
+local view_mode   = http.formvalue("mode")  or saved_mode
 if view_mode ~= "daily" and view_mode ~= "monthly" then view_mode = "daily" end
 
 local stats, title = {}, ""
@@ -106,7 +104,6 @@ if cur_iface ~= "" then
     end
 end
 
--- Totals for summary bar
 local total_rx, total_tx = 0, 0
 for _, s in ipairs(stats) do
     total_rx = total_rx + (s.rx or 0)
@@ -114,90 +111,7 @@ for _, s in ipairs(stats) do
 end
 %>
 
-<style>
-/* ── Scoped to .netstat-dashboard to avoid leaking into LuCI ── */
-.netstat-dashboard {
-    border: 1px solid var(--ns-border, #dfe3eb);
-    border-radius: 10px;
-    background: var(--ns-bg, #fff);
-    padding: 16px 18px;
-}
-
-/* Summary bar ── */
-.netstat-summary {
-    display: flex;
-    gap: 12px;
-    flex-wrap: wrap;
-    margin-bottom: 16px;
-    padding: 10px 14px;
-    background: var(--ns-summary-bg, #f7f9fc);
-    border: 1px solid var(--ns-border, #dfe3eb);
-    border-radius: 8px;
-    font-size: 13px;
-}
-.netstat-summary-item {
-    display: flex;
-    align-items: center;
-    gap: 6px;
-    font-weight: 600;
-    color: var(--ns-text, #374151);
-}
-.netstat-summary-dot {
-    width: 10px;
-    height: 10px;
-    border-radius: 50%;
-    flex-shrink: 0;
-}
-.netstat-summary-dot.rx { background: #16a34a; }
-.netstat-summary-dot.tx { background: #d97706; }
-.netstat-summary-label  { color: var(--ns-muted, #6b7280); font-weight: 400; margin-right: 2px; }
-
-/* Chart wrap ── */
-.netstat-chart-wrap {
-    border: 1px solid var(--ns-border, #dfe4ea);
-    border-radius: 8px;
-    padding: 14px;
-    background: var(--ns-bg, #fff);
-}
-.netstat-chart-header {
-    display: flex;
-    justify-content: space-between;
-    align-items: center;
-    margin-bottom: 10px;
-    flex-wrap: wrap;
-    gap: 6px;
-}
-.netstat-chart-title {
-    margin: 0;
-    font-size: 15px;
-    font-weight: 600;
-    color: var(--ns-text, #1f2937);
-}
-.netstat-chart-badge {
-    font-size: 11px;
-    font-weight: 600;
-    padding: 2px 8px;
-    border-radius: 999px;
-    background: var(--ns-badge-bg, #e0f2fe);
-    color: var(--ns-badge-text, #0369a1);
-}
-.netstat-chart-canvas { width: 100%; display: block; }
-
-/* Loading/empty states ── */
-.netstat-empty {
-    padding: 32px;
-    text-align: center;
-    color: var(--ns-muted, #6b7280);
-    font-size: 14px;
-}
-.netstat-empty-icon { font-size: 36px; display: block; margin-bottom: 8px; }
-
-@media (max-width: 640px) {
-    .netstat-dashboard  { padding: 12px; }
-    .netstat-summary    { gap: 8px; }
-    .netstat-chart-wrap { padding: 10px; }
-}
-</style>
+<link rel="stylesheet" href="/luci-static/resources/netstat/netstat-usage.css" />
 
 <div class="netstat-dashboard">
     <p style="margin:0 0 12px;font-size:13px;color:#6b7280;">
@@ -206,25 +120,23 @@ end
 
 <% if cur_iface ~= "" and #stats > 0 then %>
 
-    <%-- Summary bar --%>
     <div class="netstat-summary">
         <div class="netstat-summary-item">
             <span class="netstat-summary-dot rx"></span>
-            <span class="netstat-summary-label"><%:Download%></span>
+            <span class="netstat-summary-label"><%:Download%>:</span>
             <strong><%=fmt_bytes(total_rx)%></strong>
         </div>
         <div class="netstat-summary-item">
             <span class="netstat-summary-dot tx"></span>
-            <span class="netstat-summary-label"><%:Upload%></span>
+            <span class="netstat-summary-label"><%:Upload%>:</span>
             <strong><%=fmt_bytes(total_tx)%></strong>
         </div>
-        <div class="netstat-summary-item" style="margin-left:auto;">
-            <span class="netstat-summary-label"><%:Total%></span>
+        <div class="netstat-summary-item netstat-summary-total">
+            <span class="netstat-summary-label"><%:Total%>:</span>
             <strong><%=fmt_bytes(total_rx + total_tx)%></strong>
         </div>
     </div>
 
-    <%-- Chart --%>
     <div class="netstat-chart-wrap">
         <div class="netstat-chart-header">
             <h3 class="netstat-chart-title"><%=title%> <%:Usage%></h3>
@@ -237,52 +149,51 @@ end
     <script src="/luci-static/resources/netstat/chartjs-plugin-datalabels"></script>
     <script>
     (function () {
-        // ── Theme detection ────────────────────────────────────────────────────
         function getTextColor() {
-            const bg  = window.getComputedStyle(document.body).backgroundColor;
+            var bg  = window.getComputedStyle(document.body).backgroundColor;
             if (!bg) return '#1f2937';
-            const rgb = bg.match(/\d+/g);
+            var rgb = bg.match(/\d+/g);
             if (!rgb || rgb.length < 3) return '#1f2937';
-            const lum = (Number(rgb[0])*299 + Number(rgb[1])*587 + Number(rgb[2])*114) / 1000;
+            var lum = (Number(rgb[0])*299 + Number(rgb[1])*587 + Number(rgb[2])*114) / 1000;
             return lum < 128 ? '#f3f4f6' : '#1f2937';
         }
         function getGridColor() {
-            const t = getTextColor();
-            return t === '#1f2937' ? 'rgba(0,0,0,0.08)' : 'rgba(255,255,255,0.1)';
+            return getTextColor() === '#1f2937' ? 'rgba(0,0,0,0.08)' : 'rgba(255,255,255,0.10)';
         }
 
-        const textColor  = getTextColor();
-        const gridColor  = getGridColor();
+        var textColor = getTextColor();
+        var gridColor = getGridColor();
 
-        // ── Data ──────────────────────────────────────────────────────────────
-        const labels = [
-            <% for _, stat in ipairs(stats) do %>
-                "<%= view_mode == "daily" and stat.date or stat.month %>",
+        var labels = [
+            <% for i, stat in ipairs(stats) do
+                local lbl = view_mode == "daily" and stat.date or stat.month
+            %>"<%=lbl%>"<% if i < #stats then %>,<% end %>
             <% end %>
         ];
-        const rxData = [
-            <% for _, stat in ipairs(stats) do %><%= math.floor(stat.rx) %>,<% end %>
+        var rxData = [
+            <% for i, stat in ipairs(stats) do
+            %><%= math.floor(stat.rx) %><% if i < #stats then %>,<% end %>
+            <% end %>
         ];
-        const txData = [
-            <% for _, stat in ipairs(stats) do %><%= math.floor(stat.tx) %>,<% end %>
+        var txData = [
+            <% for i, stat in ipairs(stats) do
+            %><%= math.floor(stat.tx) %><% if i < #stats then %>,<% end %>
+            <% end %>
         ];
 
-        // ── Canvas sizing (min 48px per row, max 600px) ───────────────────────
-        const BAR_H = 48;
-        const canvas = document.getElementById('trafficChart');
+        var BAR_H  = 48;
+        var canvas = document.getElementById('trafficChart');
         canvas.height = Math.min(Math.max(labels.length * BAR_H, 280), 700);
 
-        const ctx = canvas.getContext('2d');
+        var ctx = canvas.getContext('2d');
 
-        // ── Gradient for RX bars ──────────────────────────────────────────────
         function rxGradient() {
-            const g = ctx.createLinearGradient(0, 0, canvas.width || 600, 0);
-            g.addColorStop(0, '#86efac');  // green-300
-            g.addColorStop(1, '#15803d');  // green-700
+            var g = ctx.createLinearGradient(0, 0, canvas.width || 600, 0);
+            g.addColorStop(0, '#86efac');
+            g.addColorStop(1, '#15803d');
             return g;
         }
 
-        // ── Format helper (same as Lua side) ─────────────────────────────────
         function fmtBytes(v) {
             if (v >= 1099511627776) return (v/1099511627776).toFixed(2) + ' TB';
             if (v >= 1073741824)   return (v/1073741824).toFixed(2) + ' GB';
@@ -291,7 +202,8 @@ end
             return v + ' B';
         }
 
-        // ── Chart.js config ───────────────────────────────────────────────────
+        var maxVal = Math.max.apply(null, rxData.concat(txData).concat([1]));
+
         new Chart(ctx, {
             type: 'bar',
             data: {
@@ -300,7 +212,7 @@ end
                     {
                         label: '<%:Download (RX)%>',
                         data: rxData,
-                        backgroundColor: rxData.map(() => rxGradient()),
+                        backgroundColor: rxData.map(function() { return rxGradient(); }),
                         borderRadius: 4,
                         borderSkipped: false,
                         datalabels: {
@@ -309,11 +221,8 @@ end
                             align: 'center',
                             font: { size: 11, weight: '600' },
                             formatter: fmtBytes,
-                            // Hide label when bar is too narrow to fit text
-                            display: ctx => {
-                                const v = ctx.dataset.data[ctx.dataIndex];
-                                const max = Math.max(...rxData, ...txData);
-                                return max > 0 && v / max > 0.08;
+                            display: function(ctx) {
+                                return maxVal > 0 && ctx.dataset.data[ctx.dataIndex] / maxVal > 0.08;
                             }
                         }
                     },
@@ -329,10 +238,8 @@ end
                             align: 'right',
                             font: { size: 11, weight: '600' },
                             formatter: fmtBytes,
-                            display: ctx => {
-                                const v = ctx.dataset.data[ctx.dataIndex];
-                                const max = Math.max(...rxData, ...txData);
-                                return max > 0 && v / max > 0.02;
+                            display: function(ctx) {
+                                return maxVal > 0 && ctx.dataset.data[ctx.dataIndex] / maxVal > 0.02;
                             }
                         }
                     }
@@ -340,7 +247,7 @@ end
             },
             options: {
                 indexAxis: 'y',
-                responsive: false,      // we set height manually above
+                responsive: false,
                 maintainAspectRatio: false,
                 animation: { duration: 400 },
                 plugins: {
@@ -355,14 +262,13 @@ end
                     },
                     tooltip: {
                         callbacks: {
-                            label: ctx => ' ' + fmtBytes(ctx.raw)
+                            label: function(ctx) { return ' ' + fmtBytes(ctx.raw); }
                         }
                     }
                 },
                 scales: {
                     x: {
                         grid:  { color: gridColor },
-                        border:{ dash: [4,4] },
                         ticks: {
                             color: textColor,
                             callback: fmtBytes,
@@ -382,14 +288,14 @@ end
 
 <% elseif #ifaces == 0 then %>
     <div class="netstat-empty">
-        <span class="netstat-empty-icon">📡</span>
+        <span class="netstat-empty-icon">&#128225;</span>
         <%:No vnStat interfaces were found. Make sure vnStat has been initialized.%>
     </div>
 <% else %>
     <div class="netstat-empty">
-        <span class="netstat-empty-icon">📊</span>
-        <%:No data available for %> <strong><%=cur_iface%></strong>
-        <div style="margin-top:6px;font-size:12px;">
+        <span class="netstat-empty-icon">&#128202;</span>
+        <%:No data available for%> <strong><%=cur_iface%></strong>
+        <div class="netstat-hint">
             <%:vnStat may still be collecting its first data. Try again in a few minutes.%>
         </div>
     </div>

--- a/files/usr/lib/lua/luci/view/netstat/usage.htm
+++ b/files/usr/lib/lua/luci/view/netstat/usage.htm
@@ -3,77 +3,46 @@ local sys  = require "luci.sys"
 local http = require "luci.http"
 local uci  = require "luci.model.uci".cursor()
 
+-- ── Helpers ────────────────────────────────────────────────────────────────────
 local function to_bytes(value, unit)
-    local multipliers = {
-        ["KiB"] = 1024,
-        ["MiB"] = 1024^2,
-        ["GiB"] = 1024^3,
-        ["TiB"] = 1024^4
-    }
-    return tonumber(value) * (multipliers[unit] or 1)
+    local m = { KiB=1024, MiB=1024^2, GiB=1024^3, TiB=1024^4 }
+    return tonumber(value) * (m[unit] or 1)
 end
 
 local function format_date(date_str)
-    local month_names = {"Jan", "Feb", "Mar", "Apr", "May", "Jun",
-                         "Jul", "Aug", "Sep", "Oct", "Nov", "Dec"}
+    local months = {"Jan","Feb","Mar","Apr","May","Jun",
+                    "Jul","Aug","Sep","Oct","Nov","Dec"}
     local m, d, y = date_str:match("(%d%d)/(%d%d)/(%d%d)")
     if m and d and y then
-        return string.format("%02d %s %02d", tonumber(d), month_names[tonumber(m)], tonumber(y))
+        return string.format("%02d %s %02d", tonumber(d), months[tonumber(m)], tonumber(y))
     end
     return date_str
 end
 
-local function today_label()
-    return os.date("%d %b %y")
-end
+local function today_label()    return os.date("%d %b %y") end
+local function curmonth_label() return os.date("%b '%y")   end
 
-local function current_month_label()
-    return os.date("%b '%y")
-end
-
-local function ensure_current_daily(stats)
-    local label = today_label()
-    for _, stat in ipairs(stats) do
-        if stat.date == label then
-            return stats
-        end
-    end
-
-    table.insert(stats, {
-        date = label,
-        rx = 0,
-        tx = 0
-    })
-
+local function ensure_today(stats)
+    local lbl = today_label()
+    for _, s in ipairs(stats) do if s.date == lbl then return stats end end
+    table.insert(stats, { date=lbl, rx=0, tx=0 })
     return stats
 end
 
-local function ensure_current_monthly(stats)
-    local label = current_month_label()
-    for _, stat in ipairs(stats) do
-        if stat.month == label then
-            return stats
-        end
-    end
-
-    table.insert(stats, {
-        month = label,
-        rx = 0,
-        tx = 0
-    })
-
+local function ensure_curmonth(stats)
+    local lbl = curmonth_label()
+    for _, s in ipairs(stats) do if s.month == lbl then return stats end end
+    table.insert(stats, { month=lbl, rx=0, tx=0 })
     return stats
 end
 
 local function get_interfaces()
     local ifaces = {}
-    local p = io.popen("ls /etc/vnstat/ 2>/dev/null | grep -v '.conf$' | grep -v '.old$'")
+    local p = io.popen("ls /etc/vnstat/ 2>/dev/null | grep -Ev '\\.(conf|old)$'")
     if p then
         for iface in p:lines() do
             iface = iface:match("^%s*(.-)%s*$")
-            if iface ~= "" then
-                table.insert(ifaces, iface)
-            end
+            if iface ~= "" then table.insert(ifaces, iface) end
         end
         p:close()
     end
@@ -83,240 +52,346 @@ end
 
 local function get_daily_stats(iface)
     local stats = {}
-    local output = sys.exec("vnstat -i " .. iface .. " --days 2>/dev/null") or ""
-    for date, rx_val, rx_unit, tx_val, tx_unit in
-        output:gmatch("(%d%d/%d%d/%d%d)%s+([%d%.]+)%s+([KMGT]iB)%s+|%s+([%d%.]+)%s+([KMGT]iB)") do
+    local out = sys.exec("vnstat -i " .. iface .. " --days 2>/dev/null") or ""
+    for date, rx_v, rx_u, tx_v, tx_u in
+        out:gmatch("(%d%d/%d%d/%d%d)%s+([%d%.]+)%s+([KMGT]iB)%s+|%s+([%d%.]+)%s+([KMGT]iB)") do
         table.insert(stats, {
             date = format_date(date),
-            rx = to_bytes(rx_val, rx_unit),
-            tx = to_bytes(tx_val, tx_unit)
+            rx   = to_bytes(rx_v, rx_u),
+            tx   = to_bytes(tx_v, tx_u)
         })
     end
-    return ensure_current_daily(stats)
+    return ensure_today(stats)
 end
 
 local function get_monthly_stats(iface)
     local stats = {}
-    local output = sys.exec("vnstat -i " .. iface .. " --months 2>/dev/null") or ""
-    for month, rx_val, rx_unit, tx_val, tx_unit in
-        output:gmatch("(%a+%s+'%d%d)%s+([%d%.]+)%s+([KMGT]iB)%s+|%s+([%d%.]+)%s+([KMGT]iB)") do
+    local out = sys.exec("vnstat -i " .. iface .. " --months 2>/dev/null") or ""
+    for month, rx_v, rx_u, tx_v, tx_u in
+        out:gmatch("(%a+%s+'%d%d)%s+([%d%.]+)%s+([KMGT]iB)%s+|%s+([%d%.]+)%s+([KMGT]iB)") do
         table.insert(stats, {
             month = month,
-            rx = to_bytes(rx_val, rx_unit),
-            tx = to_bytes(tx_val, tx_unit)
+            rx    = to_bytes(rx_v, rx_u),
+            tx    = to_bytes(tx_v, tx_u)
         })
     end
-    return ensure_current_monthly(stats)
+    return ensure_curmonth(stats)
 end
 
-local function format_bytes(value)
-    if value >= 1099511627776 then
-        return string.format("%.2f TB", value / 1099511627776)
-    elseif value >= 1073741824 then
-        return string.format("%.2f GB", value / 1073741824)
-    elseif value >= 1048576 then
-        return string.format("%.2f MB", value / 1048576)
-    elseif value >= 1024 then
-        return string.format("%.2f KB", value / 1024)
+local function fmt_bytes(v)
+    if v >= 1099511627776 then return string.format("%.2f TB", v/1099511627776)
+    elseif v >= 1073741824 then return string.format("%.2f GB", v/1073741824)
+    elseif v >= 1048576    then return string.format("%.2f MB", v/1048576)
+    elseif v >= 1024       then return string.format("%.2f KB", v/1024)
     end
-    return tostring(value) .. " B"
+    return tostring(v) .. " B"
 end
 
-local ifaces = get_interfaces()
-local saved_iface = uci:get("netstats", "@config[0]", "prefer") or ""
-local saved_mode = uci:get("netstats", "@config[0]", "mode") or "daily"
-local current_iface = http.formvalue("iface") or saved_iface or ifaces[1] or ""
-local view_mode = http.formvalue("mode") or saved_mode
-if view_mode ~= "daily" and view_mode ~= "monthly" then
-    view_mode = "daily"
-end
-local stats = {}
-local title = ""
+-- ── Load data ──────────────────────────────────────────────────────────────────
+local ifaces       = get_interfaces()
+local saved_iface  = uci:get("netstats", "@config[0]", "prefer") or ""
+local saved_mode   = uci:get("netstats", "@config[0]", "mode")   or "daily"
+local cur_iface    = http.formvalue("iface") or saved_iface or ifaces[1] or ""
+local view_mode    = http.formvalue("mode")  or saved_mode
+if view_mode ~= "daily" and view_mode ~= "monthly" then view_mode = "daily" end
 
-if current_iface ~= "" then
+local stats, title = {}, ""
+if cur_iface ~= "" then
     if view_mode == "monthly" then
-        stats = get_monthly_stats(current_iface)
+        stats = get_monthly_stats(cur_iface)
         title = translate("Monthly")
     else
-        stats = get_daily_stats(current_iface)
+        stats = get_daily_stats(cur_iface)
         title = translate("Daily")
     end
 end
 
-local total_rx = 0
-local total_tx = 0
-for _, stat in ipairs(stats) do
-    total_rx = total_rx + (stat.rx or 0)
-    total_tx = total_tx + (stat.tx or 0)
+-- Totals for summary bar
+local total_rx, total_tx = 0, 0
+for _, s in ipairs(stats) do
+    total_rx = total_rx + (s.rx or 0)
+    total_tx = total_tx + (s.tx or 0)
 end
 %>
 
 <style>
+/* ── Scoped to .netstat-dashboard to avoid leaking into LuCI ── */
 .netstat-dashboard {
-    border: 1px solid #dfe3eb;
+    border: 1px solid var(--ns-border, #dfe3eb);
     border-radius: 10px;
-    background: #fff;
+    background: var(--ns-bg, #fff);
     padding: 16px 18px;
-    margin-top: 0;
 }
 
-.netstat-chart-wrap {
-    border: 1px solid #dfe4ea;
+/* Summary bar ── */
+.netstat-summary {
+    display: flex;
+    gap: 12px;
+    flex-wrap: wrap;
+    margin-bottom: 16px;
+    padding: 10px 14px;
+    background: var(--ns-summary-bg, #f7f9fc);
+    border: 1px solid var(--ns-border, #dfe3eb);
     border-radius: 8px;
-    padding: 12px;
-    background: #fff;
+    font-size: 13px;
 }
+.netstat-summary-item {
+    display: flex;
+    align-items: center;
+    gap: 6px;
+    font-weight: 600;
+    color: var(--ns-text, #374151);
+}
+.netstat-summary-dot {
+    width: 10px;
+    height: 10px;
+    border-radius: 50%;
+    flex-shrink: 0;
+}
+.netstat-summary-dot.rx { background: #16a34a; }
+.netstat-summary-dot.tx { background: #d97706; }
+.netstat-summary-label  { color: var(--ns-muted, #6b7280); font-weight: 400; margin-right: 2px; }
 
+/* Chart wrap ── */
+.netstat-chart-wrap {
+    border: 1px solid var(--ns-border, #dfe4ea);
+    border-radius: 8px;
+    padding: 14px;
+    background: var(--ns-bg, #fff);
+}
+.netstat-chart-header {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    margin-bottom: 10px;
+    flex-wrap: wrap;
+    gap: 6px;
+}
 .netstat-chart-title {
-    margin: 0 0 10px;
+    margin: 0;
     font-size: 15px;
-    color: #1f2937;
+    font-weight: 600;
+    color: var(--ns-text, #1f2937);
 }
+.netstat-chart-badge {
+    font-size: 11px;
+    font-weight: 600;
+    padding: 2px 8px;
+    border-radius: 999px;
+    background: var(--ns-badge-bg, #e0f2fe);
+    color: var(--ns-badge-text, #0369a1);
+}
+.netstat-chart-canvas { width: 100%; display: block; }
 
-.netstat-chart-canvas {
-    width: 100%;
-    min-height: 320px;
+/* Loading/empty states ── */
+.netstat-empty {
+    padding: 32px;
+    text-align: center;
+    color: var(--ns-muted, #6b7280);
+    font-size: 14px;
 }
+.netstat-empty-icon { font-size: 36px; display: block; margin-bottom: 8px; }
 
 @media (max-width: 640px) {
-    .netstat-dashboard {
-        padding: 12px;
-    }
-
-    .netstat-chart-canvas {
-        min-height: 280px;
-    }
+    .netstat-dashboard  { padding: 12px; }
+    .netstat-summary    { gap: 8px; }
+    .netstat-chart-wrap { padding: 10px; }
 }
 </style>
 
 <div class="netstat-dashboard">
-    <p><%:Usage is displayed using the Interface and View Mode selected in the Settings tab.%></p>
+    <p style="margin:0 0 12px;font-size:13px;color:#6b7280;">
+        <%:Usage is displayed using the Interface and View Mode selected in the Settings tab.%>
+    </p>
 
-<% if current_iface ~= "" and #stats > 0 then %>
-    <div class="netstat-chart-wrap">
-        <h3 class="netstat-chart-title"><%=title%> <%:Usage%> (<%=current_iface%>)</h3>
-        <div class="netstat-chart-canvas">
-            <canvas id="trafficChart"></canvas>
+<% if cur_iface ~= "" and #stats > 0 then %>
+
+    <%-- Summary bar --%>
+    <div class="netstat-summary">
+        <div class="netstat-summary-item">
+            <span class="netstat-summary-dot rx"></span>
+            <span class="netstat-summary-label"><%:Download%></span>
+            <strong><%=fmt_bytes(total_rx)%></strong>
         </div>
+        <div class="netstat-summary-item">
+            <span class="netstat-summary-dot tx"></span>
+            <span class="netstat-summary-label"><%:Upload%></span>
+            <strong><%=fmt_bytes(total_tx)%></strong>
+        </div>
+        <div class="netstat-summary-item" style="margin-left:auto;">
+            <span class="netstat-summary-label"><%:Total%></span>
+            <strong><%=fmt_bytes(total_rx + total_tx)%></strong>
+        </div>
+    </div>
+
+    <%-- Chart --%>
+    <div class="netstat-chart-wrap">
+        <div class="netstat-chart-header">
+            <h3 class="netstat-chart-title"><%=title%> <%:Usage%></h3>
+            <span class="netstat-chart-badge"><%=cur_iface%></span>
+        </div>
+        <canvas id="trafficChart" class="netstat-chart-canvas"></canvas>
     </div>
 
     <script src="/luci-static/resources/netstat/chart.js"></script>
     <script src="/luci-static/resources/netstat/chartjs-plugin-datalabels"></script>
     <script>
-    function getTextColor() {
-        const bodyColor = window.getComputedStyle(document.body).backgroundColor;
-        if (!bodyColor) return '#1f2937';
-        const rgb = bodyColor.match(/\d+/g).map(Number);
-        const brightness = (rgb[0] * 299 + rgb[1] * 587 + rgb[2] * 114) / 1000;
-        return brightness < 128 ? '#f3f4f6' : '#1f2937';
-    }
+    (function () {
+        // ── Theme detection ────────────────────────────────────────────────────
+        function getTextColor() {
+            const bg  = window.getComputedStyle(document.body).backgroundColor;
+            if (!bg) return '#1f2937';
+            const rgb = bg.match(/\d+/g);
+            if (!rgb || rgb.length < 3) return '#1f2937';
+            const lum = (Number(rgb[0])*299 + Number(rgb[1])*587 + Number(rgb[2])*114) / 1000;
+            return lum < 128 ? '#f3f4f6' : '#1f2937';
+        }
+        function getGridColor() {
+            const t = getTextColor();
+            return t === '#1f2937' ? 'rgba(0,0,0,0.08)' : 'rgba(255,255,255,0.1)';
+        }
 
-    const textColor = getTextColor();
-    const barHeight = 52;
-    const chartCanvas = document.getElementById('trafficChart');
-    chartCanvas.height = Math.max(320, <%= #stats %> * barHeight);
-    const ctx = chartCanvas.getContext('2d');
+        const textColor  = getTextColor();
+        const gridColor  = getGridColor();
 
-    function getGradient(ctx) {
-        const gradient = ctx.createLinearGradient(0, 0, chartCanvas.width, 0);
-        gradient.addColorStop(0, '#84cc16');
-        gradient.addColorStop(1, '#166534');
-        return gradient;
-    }
+        // ── Data ──────────────────────────────────────────────────────────────
+        const labels = [
+            <% for _, stat in ipairs(stats) do %>
+                "<%= view_mode == "daily" and stat.date or stat.month %>",
+            <% end %>
+        ];
+        const rxData = [
+            <% for _, stat in ipairs(stats) do %><%= math.floor(stat.rx) %>,<% end %>
+        ];
+        const txData = [
+            <% for _, stat in ipairs(stats) do %><%= math.floor(stat.tx) %>,<% end %>
+        ];
 
-    function formatBytes(value) {
-        if (value > 1099511627776) return (value / 1099511627776).toFixed(2) + ' TB';
-        if (value > 1073741824) return (value / 1073741824).toFixed(2) + ' GB';
-        if (value > 1048576) return (value / 1048576).toFixed(2) + ' MB';
-        if (value > 1024) return (value / 1024).toFixed(2) + ' KB';
-        return value + ' B';
-    }
+        // ── Canvas sizing (min 48px per row, max 600px) ───────────────────────
+        const BAR_H = 48;
+        const canvas = document.getElementById('trafficChart');
+        canvas.height = Math.min(Math.max(labels.length * BAR_H, 280), 700);
 
-    const rxData = [
-        <% for _, stat in ipairs(stats) do %>
-            <%= math.floor(stat.rx) %>,
-        <% end %>
-    ];
-    const txData = [
-        <% for _, stat in ipairs(stats) do %>
-            <%= math.floor(stat.tx) %>,
-        <% end %>
-    ];
+        const ctx = canvas.getContext('2d');
 
-    new Chart(ctx, {
-        type: 'bar',
-        data: {
-            labels: [
-                <% for _, stat in ipairs(stats) do %>
-                    "<%= view_mode == "daily" and stat.date or stat.month %>",
-                <% end %>
-            ],
-            datasets: [
-                {
-                    label: '<%:Download (RX)%>',
-                    backgroundColor: rxData.map(() => getGradient(ctx)),
-                    data: rxData,
-                    datalabels: {
-                        color: '#f8fafc',
-                        anchor: 'center',
-                        align: 'center',
-                        formatter: function(value) { return formatBytes(value); }
-                    }
-                },
-                {
-                    label: '<%:Upload (TX)%>',
-                    backgroundColor: '#f59e0b',
-                    data: txData,
-                    datalabels: {
-                        color: textColor,
-                        anchor: 'end',
-                        align: 'right',
-                        formatter: function(value) { return formatBytes(value); }
-                    }
-                }
-            ]
-        },
-        options: {
-            indexAxis: 'y',
-            responsive: true,
-            maintainAspectRatio: false,
-            plugins: {
-                legend: {
-                    position: 'top',
-                    labels: { color: textColor }
-                },
-                tooltip: {
-                    callbacks: {
-                        label: function(context) {
-                            return formatBytes(context.raw);
+        // ── Gradient for RX bars ──────────────────────────────────────────────
+        function rxGradient() {
+            const g = ctx.createLinearGradient(0, 0, canvas.width || 600, 0);
+            g.addColorStop(0, '#86efac');  // green-300
+            g.addColorStop(1, '#15803d');  // green-700
+            return g;
+        }
+
+        // ── Format helper (same as Lua side) ─────────────────────────────────
+        function fmtBytes(v) {
+            if (v >= 1099511627776) return (v/1099511627776).toFixed(2) + ' TB';
+            if (v >= 1073741824)   return (v/1073741824).toFixed(2) + ' GB';
+            if (v >= 1048576)      return (v/1048576).toFixed(2) + ' MB';
+            if (v >= 1024)         return (v/1024).toFixed(2) + ' KB';
+            return v + ' B';
+        }
+
+        // ── Chart.js config ───────────────────────────────────────────────────
+        new Chart(ctx, {
+            type: 'bar',
+            data: {
+                labels: labels,
+                datasets: [
+                    {
+                        label: '<%:Download (RX)%>',
+                        data: rxData,
+                        backgroundColor: rxData.map(() => rxGradient()),
+                        borderRadius: 4,
+                        borderSkipped: false,
+                        datalabels: {
+                            color: '#fff',
+                            anchor: 'center',
+                            align: 'center',
+                            font: { size: 11, weight: '600' },
+                            formatter: fmtBytes,
+                            // Hide label when bar is too narrow to fit text
+                            display: ctx => {
+                                const v = ctx.dataset.data[ctx.dataIndex];
+                                const max = Math.max(...rxData, ...txData);
+                                return max > 0 && v / max > 0.08;
+                            }
                         }
+                    },
+                    {
+                        label: '<%:Upload (TX)%>',
+                        data: txData,
+                        backgroundColor: '#f59e0b',
+                        borderRadius: 4,
+                        borderSkipped: false,
+                        datalabels: {
+                            color: textColor,
+                            anchor: 'end',
+                            align: 'right',
+                            font: { size: 11, weight: '600' },
+                            formatter: fmtBytes,
+                            display: ctx => {
+                                const v = ctx.dataset.data[ctx.dataIndex];
+                                const max = Math.max(...rxData, ...txData);
+                                return max > 0 && v / max > 0.02;
+                            }
+                        }
+                    }
+                ]
+            },
+            options: {
+                indexAxis: 'y',
+                responsive: false,      // we set height manually above
+                maintainAspectRatio: false,
+                animation: { duration: 400 },
+                plugins: {
+                    legend: {
+                        position: 'top',
+                        labels: {
+                            color: textColor,
+                            usePointStyle: true,
+                            pointStyle: 'circle',
+                            padding: 16
+                        }
+                    },
+                    tooltip: {
+                        callbacks: {
+                            label: ctx => ' ' + fmtBytes(ctx.raw)
+                        }
+                    }
+                },
+                scales: {
+                    x: {
+                        grid:  { color: gridColor },
+                        border:{ dash: [4,4] },
+                        ticks: {
+                            color: textColor,
+                            callback: fmtBytes,
+                            maxTicksLimit: 6
+                        }
+                    },
+                    y: {
+                        grid:  { display: false },
+                        ticks: { color: textColor, autoSkip: false }
                     }
                 }
             },
-            scales: {
-                x: {
-                    ticks: {
-                        color: textColor,
-                        callback: function(value) {
-                            return formatBytes(value);
-                        }
-                    }
-                },
-                y: {
-                    ticks: { color: textColor, autoSkip: false }
-                }
-            }
-        },
-        plugins: [ChartDataLabels]
-    });
+            plugins: [ChartDataLabels]
+        });
+    })();
     </script>
+
+<% elseif #ifaces == 0 then %>
+    <div class="netstat-empty">
+        <span class="netstat-empty-icon">📡</span>
+        <%:No vnStat interfaces were found. Make sure vnStat has been initialized.%>
+    </div>
 <% else %>
-    <div class="alert-message warning">
-        <% if #ifaces == 0 then %>
-            <%:No vnStat interfaces were found. Make sure vnStat has been initialized.%>
-        <% else %>
-            <%:No data available for %> <%= current_iface %>
-        <% end %>
+    <div class="netstat-empty">
+        <span class="netstat-empty-icon">📊</span>
+        <%:No data available for %> <strong><%=cur_iface%></strong>
+        <div style="margin-top:6px;font-size:12px;">
+            <%:vnStat may still be collecting its first data. Try again in a few minutes.%>
+        </div>
     </div>
 <% end %>
 </div>

--- a/files/www/luci-static/resources/netstat/netstat-usage.css
+++ b/files/www/luci-static/resources/netstat/netstat-usage.css
@@ -1,0 +1,109 @@
+/* netstat-usage.css */
+.netstat-dashboard {
+    border: 1px solid #dfe3eb;
+    border-radius: 10px;
+    background: #fff;
+    padding: 16px 18px;
+}
+
+.netstat-summary {
+    display: flex;
+    gap: 12px;
+    flex-wrap: wrap;
+    margin-bottom: 16px;
+    padding: 10px 14px;
+    background: #f7f9fc;
+    border: 1px solid #dfe3eb;
+    border-radius: 8px;
+    font-size: 13px;
+}
+
+.netstat-summary-item {
+    display: flex;
+    align-items: center;
+    gap: 6px;
+    font-weight: 600;
+    color: #374151;
+}
+
+.netstat-summary-dot {
+    width: 10px;
+    height: 10px;
+    border-radius: 50%;
+    flex-shrink: 0;
+}
+
+.netstat-summary-dot.rx { background: #16a34a; }
+.netstat-summary-dot.tx { background: #d97706; }
+
+.netstat-summary-label {
+    color: #6b7280;
+    font-weight: 400;
+    margin-right: 2px;
+}
+
+.netstat-summary-total {
+    margin-left: auto;
+}
+
+.netstat-chart-wrap {
+    border: 1px solid #dfe4ea;
+    border-radius: 8px;
+    padding: 14px;
+    background: #fff;
+}
+
+.netstat-chart-header {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    margin-bottom: 10px;
+    flex-wrap: wrap;
+    gap: 6px;
+}
+
+.netstat-chart-title {
+    margin: 0;
+    font-size: 15px;
+    font-weight: 600;
+    color: #1f2937;
+}
+
+.netstat-chart-badge {
+    font-size: 11px;
+    font-weight: 600;
+    padding: 2px 8px;
+    border-radius: 999px;
+    background: #e0f2fe;
+    color: #0369a1;
+}
+
+.netstat-chart-canvas {
+    width: 100%;
+    display: block;
+}
+
+.netstat-empty {
+    padding: 32px;
+    text-align: center;
+    color: #6b7280;
+    font-size: 14px;
+}
+
+.netstat-empty-icon {
+    font-size: 36px;
+    display: block;
+    margin-bottom: 8px;
+}
+
+.netstat-hint {
+    margin-top: 6px;
+    font-size: 12px;
+    color: #9ca3af;
+}
+
+@media (max-width: 640px) {
+    .netstat-dashboard  { padding: 12px; }
+    .netstat-summary    { gap: 8px; }
+    .netstat-chart-wrap { padding: 10px; }
+}

--- a/files/www/luci-static/resources/netstat/netstat.css
+++ b/files/www/luci-static/resources/netstat/netstat.css
@@ -1,3 +1,27 @@
+/* ── netstat.css  (light theme) ── */
+
+/* CSS custom properties – override all the scattered !important chains */
+:root {
+  --ns-bg:           #ffffff;
+  --ns-border:       #dfe3eb;
+  --ns-text:         #111111;
+  --ns-muted:        #4b5563;
+  --ns-number:       #111111;
+  --ns-unit:         #2a2a2a;
+  --ns-label:        #3a3a3a;
+  --ns-box-shadow:   rgba(0,0,0,0.05);
+  --ns-dl-color:     #1f7a3a;
+  --ns-ul-color:     #1c63b8;
+  --ns-total-color:  #222222;
+  --ns-status-up:    #1e6b2f;
+  --ns-status-down:  #b32020;
+  --ns-sep:          #111111;
+  --ns-summary-bg:   #f7f9fc;
+  --ns-badge-bg:     #e0f2fe;
+  --ns-badge-text:   #0369a1;
+}
+
+/* ── Widget wrapper ─────────────────────────────────────────────────────────── */
 .stats-grid.netstat-wrap {
   padding: 10px 0 !important;
   border-radius: 0 !important;
@@ -14,60 +38,73 @@
 .netstat-row {
   display: flex !important;
   gap: 12px !important;
-  align-items: center !important;
+  align-items: stretch !important;   /* equal-height cards */
   justify-content: center !important;
   flex-wrap: wrap !important;
   max-width: 1180px !important;
   margin: 0 auto !important;
-  padding: 0 38px !important;
+  padding: 0 16px !important;
 }
 
+/* ── Stat boxes ──────────────────────────────────────────────────────────────── */
 .netstat-box {
-  flex: 0 1 180px !important;
+  flex: 0 1 175px !important;
   min-width: 110px !important;
   max-width: 185px !important;
-  padding: 11px 10px !important;
-  background: #fff !important;
-  border: 2px solid #111 !important;
+  padding: 12px 10px !important;
+  background: var(--ns-bg) !important;
+  border: 2px solid var(--ns-border) !important;
   border-radius: 12px !important;
   text-align: center !important;
-  box-shadow: 0 2px 6px rgba(0, 0, 0, 0.05) !important;
+  box-shadow: 0 2px 6px var(--ns-box-shadow) !important;
+  transition: border-color 0.15s, box-shadow 0.15s !important;
+  display: flex !important;
+  flex-direction: column !important;
+  justify-content: center !important;
+}
+
+.netstat-box:hover {
+  border-color: #94a3b8 !important;
+  box-shadow: 0 4px 12px rgba(0,0,0,0.10) !important;
 }
 
 .netstat-center {
-  flex: 0 1 205px !important;
+  flex: 0 1 210px !important;
   min-width: 180px !important;
   border-style: dashed !important;
-  border-radius: 12px !important;
+  border-width: 2px !important;
 }
 
+/* ── Typography ─────────────────────────────────────────────────────────────── */
 .netstat-number {
   font-weight: 800 !important;
   font-size: 24px !important;
-  color: #111 !important;
+  color: var(--ns-number) !important;
   line-height: 1 !important;
 }
 
 .netstat-unit {
   font-weight: 700 !important;
   font-size: 12px !important;
-  color: #2a2a2a !important;
+  color: var(--ns-unit) !important;
   letter-spacing: 0.2px !important;
   margin-top: 4px !important;
 }
 
 .netstat-label {
-  margin-top: 5px !important;
-  font-size: 12px !important;
+  margin-top: 6px !important;
+  font-size: 11px !important;
   font-weight: 700 !important;
-  color: #3a3a3a !important;
-  text-transform: lowercase !important;
+  color: var(--ns-label) !important;
+  text-transform: uppercase !important;
+  letter-spacing: 0.6px !important;
 }
 
+/* ── Center (status) card ─────────────────────────────────────────────────── */
 .netstat-center-title {
-  font-size: 12px !important;
+  font-size: 11px !important;
   font-weight: 800 !important;
-  color: #222 !important;
+  color: var(--ns-muted) !important;
   text-transform: uppercase !important;
   letter-spacing: 0.8px !important;
 }
@@ -75,56 +112,41 @@
 .netstat-center-status {
   font-size: 15px !important;
   font-weight: 800 !important;
-  color: #1e6b2f !important;
-  margin-top: 6px !important;
+  color: var(--ns-status-up) !important;
+  margin-top: 4px !important;
 }
 
 .netstat-center-sep {
   height: 1px !important;
-  background: #111 !important;
-  opacity: 0.4 !important;
-  margin: 6px 0 !important;
+  background: var(--ns-sep) !important;
+  opacity: 0.15 !important;
+  margin: 8px 0 !important;
 }
 
 .netstat-center-ip {
-  font-size: 13px !important;
+  font-size: 12px !important;
   font-weight: 700 !important;
-  color: #111 !important;
+  color: var(--ns-text) !important;
   font-family: "Lucida Console", "Courier New", monospace !important;
   word-break: break-all !important;
+  margin-top: 4px !important;
 }
 
-.netstat-box.is-download .netstat-number {
-  color: #1f7a3a !important;
-}
+/* ── Accent colours ─────────────────────────────────────────────────────────── */
+.netstat-box.is-download .netstat-number { color: var(--ns-dl-color)    !important; }
+.netstat-box.is-upload   .netstat-number { color: var(--ns-ul-color)    !important; }
+.netstat-box.is-total    .netstat-number { color: var(--ns-total-color) !important; }
+.netstat-box.is-down .netstat-center-status { color: var(--ns-status-down) !important; }
 
-.netstat-box.is-upload .netstat-number {
-  color: #1c63b8 !important;
-}
-
-.netstat-box.is-total .netstat-number {
-  color: #222 !important;
-}
-
-.netstat-box.is-down .netstat-center-status {
-  color: #b32020 !important;
-}
-
+/* ── Responsive ─────────────────────────────────────────────────────────────── */
 @media (max-width: 900px) {
-  .netstat-row {
-    padding: 0 12px !important;
-  }
-
+  .netstat-row { padding: 0 12px !important; }
   .netstat-box,
-  .netstat-center {
-    max-width: none !important;
-    flex: 1 1 45% !important;
-  }
+  .netstat-center { max-width: none !important; flex: 1 1 45% !important; }
 }
 
 @media (max-width: 600px) {
   .netstat-box,
-  .netstat-center {
-    flex: 1 1 100% !important;
-  }
+  .netstat-center { flex: 1 1 100% !important; }
+  .netstat-number { font-size: 20px !important; }
 }

--- a/files/www/luci-static/resources/netstat/netstat_dark.css
+++ b/files/www/luci-static/resources/netstat/netstat_dark.css
@@ -1,130 +1,30 @@
-.stats-grid.netstat-wrap {
-  padding: 10px 0 !important;
-  border-radius: 0 !important;
-  border: 0 !important;
-  overflow: visible !important;
-  background: transparent !important;
-  box-shadow: none !important;
-  font-family: "Trebuchet MS", "Lucida Sans Unicode", sans-serif !important;
-  max-width: 1240px !important;
-  width: 100% !important;
-  margin: 0 auto !important;
+/* ── netstat_dark.css  (dark theme)  ── */
+/* Imports light theme then overrides only the colour tokens.
+   This eliminates ~120 lines of duplicated rules.            */
+@import url("netstat.css");
+
+:root {
+  --ns-bg:           #0f1113;
+  --ns-border:       #374151;
+  --ns-text:         #f4f4f4;
+  --ns-muted:        #9ca3af;
+  --ns-number:       #f4f4f4;
+  --ns-unit:         #d6d6d6;
+  --ns-label:        #c8c8c8;
+  --ns-box-shadow:   rgba(0,0,0,0.35);
+  --ns-dl-color:     #7fdc98;
+  --ns-ul-color:     #7db8ff;
+  --ns-total-color:  #f0f0f0;
+  --ns-status-up:    #7fdc98;
+  --ns-status-down:  #ff7d7d;
+  --ns-sep:          #e6e6e6;
+  --ns-summary-bg:   #1a1d20;
+  --ns-badge-bg:     #1e3a5f;
+  --ns-badge-text:   #93c5fd;
 }
 
-.netstat-row {
-  display: flex !important;
-  gap: 12px !important;
-  align-items: center !important;
-  justify-content: center !important;
-  flex-wrap: wrap !important;
-  max-width: 1180px !important;
-  margin: 0 auto !important;
-  padding: 0 38px !important;
-}
-
-.netstat-box {
-  flex: 0 1 180px !important;
-  min-width: 110px !important;
-  max-width: 185px !important;
-  padding: 11px 10px !important;
-  background: #0f1113 !important;
-  border: 2px solid #e6e6e6 !important;
-  border-radius: 12px !important;
-  text-align: center !important;
-  box-shadow: 0 2px 6px rgba(0, 0, 0, 0.35) !important;
-}
-
-.netstat-center {
-  flex: 0 1 205px !important;
-  min-width: 180px !important;
-  border-style: dashed !important;
-  border-radius: 12px !important;
-}
-
-.netstat-number {
-  font-weight: 800 !important;
-  font-size: 24px !important;
-  color: #f4f4f4 !important;
-  line-height: 1 !important;
-}
-
-.netstat-unit {
-  font-weight: 700 !important;
-  font-size: 12px !important;
-  color: #d6d6d6 !important;
-  letter-spacing: 0.2px !important;
-  margin-top: 4px !important;
-}
-
-.netstat-label {
-  margin-top: 5px !important;
-  font-size: 12px !important;
-  font-weight: 700 !important;
-  color: #c8c8c8 !important;
-  text-transform: lowercase !important;
-}
-
-.netstat-center-title {
-  font-size: 12px !important;
-  font-weight: 800 !important;
-  color: #e5e5e5 !important;
-  text-transform: uppercase !important;
-  letter-spacing: 0.8px !important;
-}
-
-.netstat-center-status {
-  font-size: 15px !important;
-  font-weight: 800 !important;
-  color: #7fdc98 !important;
-  margin-top: 6px !important;
-}
-
-.netstat-center-sep {
-  height: 1px !important;
-  background: #e6e6e6 !important;
-  opacity: 0.5 !important;
-  margin: 6px 0 !important;
-}
-
-.netstat-center-ip {
-  font-size: 13px !important;
-  font-weight: 700 !important;
-  color: #f4f4f4 !important;
-  font-family: "Lucida Console", "Courier New", monospace !important;
-  word-break: break-all !important;
-}
-
-.netstat-box.is-download .netstat-number {
-  color: #7fdc98 !important;
-}
-
-.netstat-box.is-upload .netstat-number {
-  color: #7db8ff !important;
-}
-
-.netstat-box.is-total .netstat-number {
-  color: #f0f0f0 !important;
-}
-
-.netstat-box.is-down .netstat-center-status {
-  color: #ff7d7d !important;
-}
-
-@media (max-width: 900px) {
-  .netstat-row {
-    padding: 0 12px !important;
-  }
-
-  .netstat-box,
-  .netstat-center {
-    max-width: none !important;
-    flex: 1 1 45% !important;
-  }
-}
-
-@media (max-width: 600px) {
-  .netstat-box,
-  .netstat-center {
-    flex: 1 1 100% !important;
-  }
+/* Dark-specific hover (slightly lighter border) */
+.netstat-box:hover {
+  border-color: #6b7280 !important;
+  box-shadow: 0 4px 12px rgba(0,0,0,0.4) !important;
 }

--- a/files/www/luci-static/resources/view/status/include/08_stats.js
+++ b/files/www/luci-static/resources/view/status/include/08_stats.js
@@ -2,258 +2,263 @@
 'require baseclass';
 'require uci';
 
-let prev = {};
-let last_time = Date.now();
+// ─── State ────────────────────────────────────────────────────────────────────
+let prev        = {};
+let last_time   = Date.now();
+let _pollAdded  = false;   // guard: only register one poll handler
+let _container  = null;    // reference to the live DOM node
 
+// ─── CSS Loader (theme-aware, no busy-poll) ───────────────────────────────────
 (function loadDynamicCSS() {
-	let lastLoadedCss = null;
+	let loadedCss = null;
 
 	function isDarkMode() {
 		try {
-			const bgColor = getComputedStyle(document.body).backgroundColor;
-			console.log('[NetStat] Body bg color:', bgColor);
-			
-			if (!bgColor || bgColor === 'transparent') return false;
-			const rgb = bgColor.match(/\d+/g);
+			const bg  = getComputedStyle(document.body).backgroundColor;
+			if (!bg || bg === 'transparent') return false;
+			const rgb = bg.match(/\d+/g);
 			if (!rgb || rgb.length < 3) return false;
 			const [r, g, b] = rgb.map(Number);
-			const luminance = (r * 299 + g * 587 + b * 114) / 1000;
-			const isDark = luminance < 100;
-			console.log('[NetStat] RGB:', r, g, b, 'Luminance:', luminance, 'isDark:', isDark);
-			return isDark;
-		} catch (e) {
-			console.error('[NetStat] Error detecting dark mode:', e);
-			return false;
-		}
+			return (r * 299 + g * 587 + b * 114) / 1000 < 100;
+		} catch (_) { return false; }
 	}
 
-	function loadCSS() {
-		const dark = isDarkMode();
-		const cssFile = dark ? 'netstat_dark.css' : 'netstat.css';
-		
-		console.log('[NetStat] loadCSS - current dark:', dark, 'last loaded:', lastLoadedCss);
-		
-		// Skip only if we just loaded this exact CSS
-		if (lastLoadedCss === cssFile) {
-			console.log('[NetStat] CSS already loaded, skipping');
-			return;
-		}
-		
-		console.log('[NetStat] Loading CSS:', cssFile);
-		lastLoadedCss = cssFile;
+	function applyCSS() {
+		const file = isDarkMode() ? 'netstat_dark.css' : 'netstat.css';
+		if (loadedCss === file) return;
+		loadedCss = file;
 
-		// Remove old CSS
-		document.querySelectorAll('link[href*="netstat.css"]').forEach(link => {
-			console.log('[NetStat] Removing old CSS:', link.href);
-			if (link.parentNode) link.parentNode.removeChild(link);
-		});
+		document.querySelectorAll('link[data-netstat-css]').forEach(l => l.remove());
 
-		// Load new CSS
-		const link = document.createElement('link');
-		link.rel = 'stylesheet';
-		link.href = '/luci-static/resources/netstat/' + cssFile + '?t=' + Date.now();
-		
-		link.onload = function() {
-			console.log('[NetStat] ✓ CSS loaded:', link.href);
-		};
-		link.onerror = function() {
-			console.error('[NetStat] ✗ CSS failed to load:', link.href);
-		};
-		
-		console.log('[NetStat] Adding link to head:', link.href);
+		const link       = document.createElement('link');
+		link.rel         = 'stylesheet';
+		link.dataset.netstatssCss = '1';
+		link.setAttribute('data-netstat-css', '1');
+		link.href        = '/luci-static/resources/netstat/' + file + '?t=' + Date.now();
 		document.head.appendChild(link);
 	}
 
-	// Initial load with short delay
-	setTimeout(() => {
-		console.log('[NetStat] Initial load');
-		loadCSS();
-	}, 100);
+	// Initial load after paint
+	requestAnimationFrame(() => setTimeout(applyCSS, 50));
 
-	// Poll every 500ms
-	setInterval(() => {
-		loadCSS();
-	}, 500);
-	
-	console.log('[NetStat] CSS loader initialized');
+	// Watch for system theme changes via matchMedia (zero polling cost)
+	if (window.matchMedia) {
+		window.matchMedia('(prefers-color-scheme: dark)').addEventListener('change', applyCSS);
+	}
+
+	// Fallback: MutationObserver on body background instead of setInterval
+	const mo = new MutationObserver(applyCSS);
+	const waitForBody = setInterval(() => {
+		if (!document.body) return;
+		clearInterval(waitForBody);
+		mo.observe(document.body, { attributes: true, attributeFilter: ['style', 'class'] });
+		applyCSS();
+	}, 50);
 })();
 
+// ─── Helpers ──────────────────────────────────────────────────────────────────
 function parseNetdev(raw) {
 	const stats = {};
-	const lines = raw.split('\n');
-	
-	for (let i = 0; i < lines.length; i++) {
-		const line = lines[i].trim();
-		if (!line || line.startsWith('face') || line.startsWith('|')) continue;
-		
-		const match = line.match(/^([^:]+):\s+(.*)$/);
-		if (!match) continue;
-		
-		const iface = match[1].trim();
-		const values = match[2].trim().split(/\s+/).map(v => parseInt(v) || 0);
-		
-		if (values.length >= 9) {
-			stats[iface] = {
-				rx: values[0],
-				tx: values[8]
-			};
-		}
+	for (const line of raw.split('\n')) {
+		const m = line.trim().match(/^([^:]+):\s+(.*)$/);
+		if (!m) continue;
+		const vals = m[2].trim().split(/\s+/).map(v => parseInt(v) || 0);
+		if (vals.length >= 9)
+			stats[m[1].trim()] = { rx: vals[0], tx: vals[8] };
 	}
-	
 	return stats;
 }
 
 function getBestWAN(stats, preferred) {
-	for (const iface of preferred) {
-		if (stats[iface]) return iface;
-	}
+	for (const i of preferred) if (stats[i]) return i;
 
 	const dynamic = Object.keys(stats).find(i =>
-		/^(wwan|usb|ppp|lte|qmi|modem)/.test(i) && i.includes('_')
-	);
+		/^(wwan|usb|ppp|lte|qmi|modem)/.test(i) && i.includes('_'));
 	if (dynamic) return dynamic;
 
-	const fallback = ['pppoe-wan', 'lte0', 'usb0', 'wan', 'eth1', 'tun0', 'wg0'];
-	for (const iface of fallback) {
-		if (stats[iface]) return iface;
-	}
+	for (const i of ['pppoe-wan','lte0','usb0','wan','eth1','tun0','wg0'])
+		if (stats[i]) return i;
 
-	const nonLo = Object.keys(stats).filter(k => k !== 'lo');
-	return nonLo[0] || 'wwan0_1';
+	return Object.keys(stats).find(k => k !== 'lo') || '';
 }
 
-function formatRate(bits) {
-	const units = ['Bps', 'Kbps', 'Mbps', 'Gbps'];
+function formatRate(bps) {
+	const units = ['Bps','Kbps','Mbps','Gbps'];
 	let i = 0;
-	while (bits >= 1000 && i < units.length - 1) {
-		bits /= 1000;
-		i++;
-	}
-	return { number: bits.toFixed(i > 0 ? 1 : 0), unit: units[i] + '/s' };
+	while (bps >= 1000 && i < units.length - 1) { bps /= 1000; i++; }
+	return { number: bps.toFixed(i > 0 ? 1 : 0), unit: units[i] + '/s' };
 }
 
-function formatBytes(value) {
-	if (value >= 1099511627776) return (value / 1099511627776).toFixed(2) + ' TB';
-	if (value >= 1073741824) return (value / 1073741824).toFixed(2) + ' GB';
-	if (value >= 1048576) return (value / 1048576).toFixed(2) + ' MB';
-	if (value >= 1024) return (value / 1024).toFixed(2) + ' KB';
-	return value + ' B';
+function formatBytes(v) {
+	if (v >= 1099511627776) return (v / 1099511627776).toFixed(2) + ' TB';
+	if (v >= 1073741824)   return (v / 1073741824).toFixed(2) + ' GB';
+	if (v >= 1048576)      return (v / 1048576).toFixed(2) + ' MB';
+	if (v >= 1024)         return (v / 1024).toFixed(2) + ' KB';
+	return v + ' B';
 }
 
+// ─── Fetch with timeout ───────────────────────────────────────────────────────
+function fetchWithTimeout(url, ms) {
+	const ctrl = typeof AbortController !== 'undefined' ? new AbortController() : null;
+	const tid   = ctrl ? setTimeout(() => ctrl.abort(), ms) : null;
+	return fetch(url, ctrl ? { signal: ctrl.signal } : {})
+		.then(r => r.json())
+		.finally(() => tid && clearTimeout(tid));
+}
+
+// ─── DOM builders ─────────────────────────────────────────────────────────────
 function createStatBox(label, value, unit, extraClass) {
-	const cls = extraClass ? 'netstat-box ' + extraClass : 'netstat-box';
+	const cls = 'netstat-box' + (extraClass ? ' ' + extraClass : '');
 	return E('div', { class: cls }, [
 		E('div', { class: 'netstat-number' }, value),
-		E('div', { class: 'netstat-unit' }, unit || ''),
+		unit ? E('div', { class: 'netstat-unit' }, unit) : null,
 		E('div', { class: 'netstat-label' }, label)
-	]);
+	].filter(Boolean));
 }
 
 function createStatusCard(status, ip) {
-	const isConnected = status === 'Connected';
-	const statusText = isConnected ? _('Connected') : _('Disconnected');
-	return E('div', { class: 'netstat-box netstat-center ' + (isConnected ? 'is-up' : 'is-down') }, [
+	const up = status === 'Connected';
+	return E('div', { class: 'netstat-box netstat-center ' + (up ? 'is-up' : 'is-down') }, [
 		E('div', { class: 'netstat-center-title' }, _('Internet')),
-		E('div', { class: 'netstat-center-status' }, statusText),
-		E('div', { class: 'netstat-center-sep' }, ''),
+		E('div', { class: 'netstat-center-status' }, up ? _('Connected') : _('Disconnected')),
+		E('div', { class: 'netstat-center-sep' }),
 		E('div', { class: 'netstat-center-title' }, _('IP')),
-		E('div', { class: 'netstat-center-ip' }, ip)
+		E('div', { class: 'netstat-center-ip' }, ip || 'N/A')
 	]);
 }
 
+// Update existing DOM nodes in-place to avoid reflowing the whole widget
+function patchText(el, sel, val) {
+	const n = el && el.querySelector(sel);
+	if (n && n.textContent !== val) n.textContent = val;
+}
+
+function updateContainer(container, data, dt) {
+	const stats    = data.stats || {};
+	const preferred = data.preferred || [];
+	const iface    = getBestWAN(stats, preferred);
+	const curr     = stats[iface] || { rx: 0, tx: 0 };
+	curr.rx = parseInt(curr.rx) || 0;
+	curr.tx = parseInt(curr.tx) || 0;
+
+	const ps       = prev[iface] || { rx: curr.rx, tx: curr.tx };
+	const rxSpeed  = Math.max(0, (curr.rx - ps.rx) / dt);
+	const txSpeed  = Math.max(0, (curr.tx - ps.tx) / dt);
+	prev[iface]    = { rx: curr.rx, tx: curr.tx };
+
+	const rxRate   = formatRate(rxSpeed * 8);
+	const txRate   = formatRate(txSpeed * 8);
+	const totalRx  = formatBytes(curr.rx).split(' ');
+	const totalTx  = formatBytes(curr.tx).split(' ');
+
+	// In-place DOM patches (no full re-render)
+	const boxes = container.querySelectorAll('.netstat-box');
+	if (boxes.length < 5) return false; // stale node, rebuild
+
+	// box 0 – download rate
+	patchText(container, '.is-download .netstat-number', rxRate.number);
+	patchText(container, '.is-download .netstat-unit',   rxRate.unit);
+	// box 1 – upload rate
+	patchText(container, '.is-upload .netstat-number',   txRate.number);
+	patchText(container, '.is-upload .netstat-unit',     txRate.unit);
+	// center – status / IP
+	const center = container.querySelector('.netstat-center');
+	if (center) {
+		const up = (data.status || '') === 'Connected';
+		center.className = 'netstat-box netstat-center ' + (up ? 'is-up' : 'is-down');
+		patchText(center, '.netstat-center-status', up ? _('Connected') : _('Disconnected'));
+		patchText(center, '.netstat-center-ip',     data.ip || 'N/A');
+	}
+	// box 3 – downloaded total
+	const totals = container.querySelectorAll('.is-total');
+	if (totals[0]) {
+		patchText(totals[0], '.netstat-number', totalRx[0]);
+		patchText(totals[0], '.netstat-unit',   totalRx[1] || '');
+	}
+	if (totals[1]) {
+		patchText(totals[1], '.netstat-number', totalTx[0]);
+		patchText(totals[1], '.netstat-unit',   totalTx[1] || '');
+	}
+	return true;
+}
+
+// ─── Main baseclass ───────────────────────────────────────────────────────────
 return baseclass.extend({
 	title: _(''),
 
-	load: function () {
-		// Direct call to getNetdevStats function via HTTP
-		return L.resolveDefault(
-			fetch('/cgi-bin/luci/admin/tools/get_netdev_stats')
-				.then(res => res.json())
-				.catch(() => ({ stats: {}, ip: 'N/A', status: 'Disconnected' })),
-			{ stats: {}, ip: 'N/A', status: 'Disconnected' }
-		).then(result => {
-			const stats = (result && result.stats) || result || {};
-			const ip = (result && result.ip) || 'N/A';
-			const status = (result && result.status) || 'Disconnected';
-			return {
-				stats: stats,
-				ip: ip,
-				status: status,
+	load() {
+		return fetchWithTimeout('/cgi-bin/luci/admin/tools/get_netdev_stats', 5000)
+			.then(r => ({
+				stats:     (r && r.stats)  || {},
+				ip:        (r && r.ip)     || 'N/A',
+				status:    (r && r.status) || 'Disconnected',
 				preferred: []
-			};
-		}).catch(() => {
-			return {
-				stats: {},
-				ip: 'N/A',
-				status: 'Disconnected',
-				preferred: []
-			};
-		});
+			}))
+			.catch(() => ({ stats: {}, ip: 'N/A', status: 'Disconnected', preferred: [] }));
 	},
 
-	render: function (data) {
-		const now = Date.now();
-		const dt = Math.max(0.1, (now - last_time) / 1000);
-		last_time = now;
+	render(data) {
+		const now  = Date.now();
+		const dt   = Math.max(0.1, (now - last_time) / 1000);
+		last_time  = now;
 
-		const stats = data.stats;
-		if (!stats || typeof stats !== 'object' || Array.isArray(stats)) {
-			return E('div', { style: 'padding: 20px; text-align: center; color: #999; font-size: 13px;' }, 
-				_('Loading network stats...')
-			);
-		}
-
+		const stats     = data.stats || {};
 		const preferred = data.preferred || [];
-		const iface = getBestWAN(stats, preferred);
-		const curr = stats[iface] || { rx: 0, tx: 0 };
-		
-		// Ensure values are numbers
+
+		if (!stats || typeof stats !== 'object' || Array.isArray(stats))
+			return E('div', { style: 'padding:20px;text-align:center;color:#999;font-size:13px' },
+				_('Loading network stats...'));
+
+		const iface    = getBestWAN(stats, preferred);
+		const curr     = stats[iface] || { rx: 0, tx: 0 };
 		curr.rx = parseInt(curr.rx) || 0;
 		curr.tx = parseInt(curr.tx) || 0;
-		
-		const prevStat = prev[iface] || { rx: curr.rx, tx: curr.tx };
 
-		let rxSpeed = Math.max(0, (curr.rx - prevStat.rx) / dt);
-		let txSpeed = Math.max(0, (curr.tx - prevStat.tx) / dt);
+		const ps       = prev[iface] || { rx: curr.rx, tx: curr.tx };
+		const rxSpeed  = Math.max(0, (curr.rx - ps.rx) / dt);
+		const txSpeed  = Math.max(0, (curr.tx - ps.tx) / dt);
+		prev[iface]    = { rx: curr.rx, tx: curr.tx };
 
-		prev[iface] = { rx: curr.rx, tx: curr.tx };
+		const rxRate   = formatRate(rxSpeed * 8);
+		const txRate   = formatRate(txSpeed * 8);
+		const totalRx  = formatBytes(curr.rx).split(' ');
+		const totalTx  = formatBytes(curr.tx).split(' ');
 
-		const rxRate = formatRate(rxSpeed * 8);
-		const txRate = formatRate(txSpeed * 8);
+		const row = E('div', { class: 'netstat-row' }, [
+			createStatBox(_('download'),   rxRate.number, rxRate.unit,   'is-download'),
+			createStatBox(_('upload'),     txRate.number, txRate.unit,   'is-upload'),
+			createStatusCard(data.status || 'Disconnected', data.ip),
+			createStatBox(_('downloaded'), totalRx[0],    totalRx[1],   'is-total'),
+			createStatBox(_('uploaded'),   totalTx[0],    totalTx[1],   'is-total'),
+		]);
 
-		const totalRx = formatBytes(curr.rx);
-		const totalTx = formatBytes(curr.tx);
+		const container = E('div', { class: 'stats-grid netstat-wrap' }, row);
+		_container = container;
 
-		const container = E('div', { class: 'stats-grid netstat-wrap' });
-		const row = E('div', { class: 'netstat-row' });
+		// ── Single poll handler (registered only once) ────────────────────────
+		if (!_pollAdded) {
+			_pollAdded = true;
+			L.Poll.add(() =>
+				fetchWithTimeout('/cgi-bin/luci/admin/tools/get_netdev_stats', 5000)
+					.then(r => {
+						const now2 = Date.now();
+						const dt2  = Math.max(0.1, (now2 - last_time) / 1000);
+						last_time  = now2;
 
-		row.appendChild(createStatBox(_('download'), rxRate.number, rxRate.unit, 'is-download'));
-		row.appendChild(createStatBox(_('upload'), txRate.number, txRate.unit, 'is-upload'));
-		const status = data.status || 'Disconnected';
-		const ip = data.ip || 'N/A';
-		row.appendChild(createStatusCard(status, ip));
-		row.appendChild(createStatBox(_('downloaded'), totalRx.split(' ')[0], totalRx.split(' ')[1] || '', 'is-total'));
-		row.appendChild(createStatBox(_('uploaded'), totalTx.split(' ')[0], totalTx.split(' ')[1] || '', 'is-total'));
-
-		container.appendChild(row);
-
-		// Set up polling for real-time updates
-		L.Poll.add(() => {
-			return L.resolveDefault(
-				fetch('/cgi-bin/luci/admin/tools/get_netdev_stats')
-					.then(res => res.json())
-					.catch(() => ({ stats: {}, ip: 'N/A', status: 'Disconnected' })),
-				{ stats: {}, ip: 'N/A', status: 'Disconnected' }
-			).then(result => {
-				const newStats = (result && result.stats) || {};
-				const newIP = (result && result.ip) || 'N/A';
-				const newStatus = (result && result.status) || 'Disconnected';
-				return this.render({ stats: newStats, ip: newIP, status: newStatus, preferred: preferred });
-			}).catch((e) => {
-				console.error('Fetch error:', e);
-				return container;
-			});
-		}, 1000);
+						// Try cheap in-place update first
+						if (_container && _container.isConnected) {
+							const ok = updateContainer(_container, {
+								stats:     (r && r.stats)  || {},
+								ip:        (r && r.ip)     || 'N/A',
+								status:    (r && r.status) || 'Disconnected',
+								preferred: []
+							}, dt2);
+							if (ok) return;
+						}
+					})
+					.catch(() => {})
+			, 2);  // poll every 2 s (was 1 s – halves request rate)
+		}
 
 		return container;
 	}


### PR DESCRIPTION
08_stats.js — biggest fix

- Bug: L.Poll.add() was called inside render(), which runs on every update cycle. This meant a new poll handler was registered every second — a serious memory leak.

- Added a _pollAdded guard so the poll handler is registered once
- Poll interval increased from 1 s → 2 s (halves server request rate with no visible difference)
- CSS loader replaced the 500 ms setInterval with a MutationObserver + matchMedia — zero polling cost
- DOM updates are now done in-place (patchText) instead of re-rendering the whole widget on every tick
- fetch wrapped with AbortController timeout (5 s hard limit)

netstat.lua (controller) — IP fetch speed
The old code tried 11 commands sequentially, each with a 4-second timeout — worst case 44 seconds of blocking. Now:

- Public-IP APIs use a 2-second timeout
- Only 4 attempts (not 11)
- Local ubus/ifstatus fallback is instant

usage.htm — UI + robustness

- Added a summary bar showing total download / upload / combined for the selected period
- Chart labels suppressed when bar is too short to fit text (prevents clutter on small values)
- Canvas height capped at 700 px (previously unbounded)
- responsive: false + manual height avoids Chart.js layout thrash
- Better empty states with icons and helpful hints

config.lua — safety

- Reset button now injects a JS confirmation dialog before submitting
- Database size displayed inline so users know what they're deleting
- Better field descriptions throughout

CSS — eliminated duplication
The dark theme was 120 lines of copy-pasted rules. Now:

- netstat.css defines everything using CSS custom properties (--ns-*)
- netstat_dark.css is just 30 lines that override the colour tokens — zero rule duplication
- Added transition on hover, align-items: stretch for equal-height cards